### PR TITLE
docs: fix images

### DIFF
--- a/wiki/Template-Specification/2023-09/How-Jobs-Are-Run.md
+++ b/wiki/Template-Specification/2023-09/How-Jobs-Are-Run.md
@@ -32,7 +32,7 @@ that the Session entered or attempted to enter, and then be terminated itself.
 
 The following diagram provides an overview of the steps taken to run a Session.
 
-![Actions Run in a Session](./how_jobs_are_run.png)
+[[how_jobs_are_run.png|Actions Run in a Session]]
 
 ## Host Requirements
 

--- a/wiki/Template-Specification/Job-Structure.md
+++ b/wiki/Template-Specification/Job-Structure.md
@@ -10,7 +10,7 @@ specific parameterized action to perform — rendering the frames of a shot, enc
 combination with a concrete set of values for its parameterization defines a ***Task***; the ***Task*** is the unit of
 schedule-able work run on  by the workers in the render management system.
 
-![Job Structure](./job_structure.png)
+[[job_structure.png|Job Structure]]
 
 The action performed by a Step is defined by the ***Step Script***. This consists of a command to run, and a set of optional
 embedded files that can be used to include the contents of a text file (shell script, python script, json document, etc) within the


### PR DESCRIPTION
GitHub wiki does not support relative paths. You need to specify an absolute path or do `[[file]]` which resolves to an absolute path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
