### PR TITLE
chore: update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,53 +6,60 @@ documentation, we greatly value feedback and contributions from our community.
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
 
+## Reporting Issues
 
-## Reporting Bugs/Feature Requests
+We welcome you to use the GitHub issue tracker to report any issues that you encounter with
+the documentation provided in this repository. When filing an issue, please check existing open,
+or recently closed, issues to make sure somebody else hasn't already reported the issue.
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+## Request for Comments
 
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+Open Job Description is under active development. We have released it because we'd like your feedback and 
+participation as we move forward, together, in defining and implementing a specification that solves the problems in 
+this space.
 
-* A reproducible test case or series of steps
-* The version of our code being used
-* Any modifications you've made relevant to the bug
-* Anything unusual about your environment or deployment
+We have provided a RFC ("Request for Comment") process for proposing changes to the specification. 
+RFCs can be created by anyone in the community, and is the process that the Open Job Description team
+uses to propose changes. If you have an idea, a kernel of an idea, a problem to solve, or want to
+provide your point of view on proposals then we encourage you to engage in this process.
 
+See the [RFC Process] guide for information on this process.
+
+[RFC process]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/rfcs
 
 ## Contributing via Pull Requests
+
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *main* branch.
+1. You are working against the latest source on the *mainline* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
 To send us a pull request, please:
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, then
+   it will be hard for us to focus on your change.
+3. Commit to your fork using clear commit messages.
+4. Send us a pull request, answering any default questions in the pull request interface.
+5. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
+Looking at the existing issues is a great way to find something to contribute on.
 
 ## Code of Conduct
+
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
-
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
 ## Licensing
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,12 +1,13 @@
 # Open Job Description RFCs
 
-This directory is the place to propose and track upcoming changes to the Open Job Description standard.
+This directory is the place to propose upcoming changes to the Open Job Description standard.
 The RFC ("Request For Comment") process is how Open Job Description achieves consensus on proposed
 changes to the formal specification. The process is intended to provide a consistent and controlled
 path for changes to the specification. 
 
-RFCs can be created by anyone in the community. If you have an idea, a kernel of an idea, or a
-problem to solve then we encourage you to engage in this process.
+RFCs can be created by anyone in the community, and is the process that the Open Job Description team
+uses to propose changes. If you have an idea, a kernel of an idea, a problem to solve, or want to
+provide your point of view on proposals then we encourage you to engage in this process.
 
 **Jump to**: [RFC Process](#rfc-process) | [RFC Process Stages](#rfc-process-stages)
 


### PR DESCRIPTION
The default CONTRIBUTING.md was geared towards repositories containing source code, but this repository does not contain code. I've updated the document to remove the source code specific parts, and to align it with the goals of this repository -- documentation improvements/fixes, and the RFC process.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
