### PR TITLE
docs: fill out README, update CONTRIBUTING and wiki home

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,22 @@
 Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
 documentation, we greatly value feedback and contributions from our community.
 
+Open Job Description is under active development. We're releasing this because we'd like your feedback and participation 
+as we move forward, together, in defining and implementing a specification that solves the problems in the space. We 
+know that, as currently specified, Open Job Description is not a cure-all for any and all workflows.
+
+* [Discussions](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions): 
+  We encourage you to post about what you would like to see in future revisions of the specification, share, and brag 
+  about how you are using Open Job Description, and engage with us and the community.
+* [Request for Comment](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/rfcs/README.md): 
+  This repository exists because we want your comments on the specification. Please consider submitting an RFC if you 
+  have thoughts on how the specification could be improved.
+* [Issues](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/issues): 
+  We encourage you to use the GitHub issue tracker to report bugs. 
+* [Pull Requests](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/pulls): 
+  We welcome pull requests to improve this wiki documentation. Simply make your changes in our [GitHub Repository](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/wiki)
+  and post a pull request.
+
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
 information to effectively respond to your bug report or contribution.
 
@@ -14,16 +30,12 @@ or recently closed, issues to make sure somebody else hasn't already reported th
 
 ## Request for Comments
 
-Open Job Description is under active development. We have released it because we'd like your feedback and 
-participation as we move forward, together, in defining and implementing a specification that solves the problems in 
-this space.
-
-We have provided a RFC ("Request for Comment") process for proposing changes to the specification. 
+We have provided an RFC ("Request for Comment") process for proposing changes to the specification.
 RFCs can be created by anyone in the community, and is the process that the Open Job Description team
 uses to propose changes. If you have an idea, a kernel of an idea, a problem to solve, or want to
 provide your point of view on proposals then we encourage you to engage in this process.
 
-See the [RFC Process] guide for information on this process.
+See the [RFC Process] README for information on this process.
 
 [RFC process]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/rfcs
 
@@ -44,10 +56,10 @@ To send us a pull request, please:
 4. Send us a pull request, answering any default questions in the pull request interface.
 5. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-## Finding contributions to work on
+## Finding Areas of Contribution
 
 Looking at the existing issues is a great way to find something to contribute on.
 
@@ -57,10 +69,15 @@ This project has adopted the [Amazon Open Source Code of Conduct](https://aws.gi
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
-## Security issue notifications
+## Security Issue Notifications
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+We take all security reports seriously. When we receive such reports, we will 
+investigate and subsequently address any potential vulnerabilities as quickly 
+as possible. If you discover a potential security issue in this project, please 
+notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
+or directly via email to [AWS Security](aws-security@amazon.com). Please do not 
+create a public GitHub issue in this project.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](LICENSE) file for our project's licensing. We will also ask you to confirm the licensing of your contribution.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,79 @@
-## Open Job Description Specifications
+# Open Job Description Specifications
 
-TODO: Fill this README out!
+This repository provides the specification for Open Job Description, a flexible 
+open-source specification for portable render jobs, both as a point of reference 
+and to drive updates from the community.
 
-Be sure to:
+Jump to:
 
-* Change the title in this README
-* Edit your repository description on GitHub
-* Write in your license below and create a LICENSE file
+* [Wiki Home](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/wiki)
+* [RFC Readme](rfcs/README.md)
+
+## Getting Started
+
+The fastest way to understand the bones of Open Job Description is to understand both [How Jobs Are Constructed](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/wiki/How-Jobs-Are-Constructed)
+and [How Jobs Are Run](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/wiki/How-Jobs-Are-Run).
+
+## What is Open Job Description?
+
+Open Job Description is a flexible open-source specification for defining render 
+jobs which are portable between studios and render solutions. 
+
+We created Open Job Description after hearing frequently from studios that they 
+found the choice of render farm management tools to be daunting due to the 
+effort required to update or replace their tooling around the render farm. We 
+also heard from software developers that they were unable to realistically 
+release render farm plugins for their own applications despite being the most 
+qualified to do so, as the render farm landscape was fractured and releasing 
+multiple plugins for different render farm solutions would quickly siphon all 
+their development capacity away from improving their software. A standard way of 
+defining render jobs, or really any type of work suited for completion on a 
+render farm, makes tools and plugins portable and increases interoperability. 
+
+For deeper insight into our thought process and goals, we recommend [this Academy Software Foundation talk](https://www.youtube.com/watch?v=3AM3L6P-cAw&list=PL9dZxafYCWmxDFGc2CEq4SgCkZWKYW1m5&index=14)
+by Pauline Koh, Senior Product Manager at Amazon Web Services, titled 
+*Portable Jobs for Open Source Content Production*.
+
+## Contributing
+
+Open Job Description is under active development. We're releasing this because 
+we'd like your feedback and participation as we move forward, together, in 
+defining and implementing a specification that solves the problems in the space. 
+We know that, as currently specified, Open Job Description is not a cure-all 
+for any and all workflows.
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for a more detailed description of how to 
+contribute, and the [RFC Readme](rfcs/README.md) for how to contribute an RFC. 
+
+We look forward to your input.
+
+* [Discussions](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions): 
+  We encourage you to post about what you would like to see in future revisions 
+  of the specification, share, and brag about how you are using Open Job 
+  Description, and engage with us and the community.
+* [Request for Comment](rfcs/README.md): 
+  This repository exists because we want your comments on the specification. 
+  Please consider submitting an RFC if you have thoughts on how the 
+  specification could be improved.
+* [Issues](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/issues): 
+  We encourage you to use the GitHub issue tracker to report bugs. 
+* [Pull Requests](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/pulls): 
+  We welcome pull requests to improve this wiki documentation. Simply make your 
+  changes in our [GitHub Repository](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/wiki)
+  and post a pull request.
+
+## Getting Help
+
+* [Discussions](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions): 
+  Seek help via our GitHub Discussions forum.
 
 ## Security
 
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more 
+information.
 
 ## License
 
-This library is licensed under the CC-BY-ND 4.0 License.
+See the [LICENSE](LICENSE) file for our project's licensing. We will also ask 
+you to confirm the licensing of your contribution.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -10,7 +10,7 @@ We created Open Job Description after hearing frequently from AWS Thinkbox Deadl
 choice of render farm management tools to be daunting due to the effort required to update or replace their tooling 
 around the render farm. We also heard from software developers that they were unable to realistically release render
 farm plugins for their own applications despite being the most qualified to do so, as the render farm landscape was 
-fractured and releasing multiple plugins for different render farm solutions would quickly siphon all of their
+fractured and releasing multiple plugins for different render farm solutions would quickly siphon all their
 development capacity away from improving their software. A standard way of defining render jobs, or really any type 
 of work suited for completion on a render farm, makes tools and plugins portable and increases interoperability. 
 
@@ -40,9 +40,4 @@ We want your input! Please see our [Contributing Guidelines](https://github.com/
   to report bugs. 
 * [Pull Requests](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/pulls): We welcome pull requests to improve this wiki
   documentation. Simply make your changes in our [GitHub Repository](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/wiki)
-  and post a pull request. 
-
-## Getting Help
-
-* [Discussions](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions): Seek help via our GitHub
-  Discussions forum.
+  and post a pull request.


### PR DESCRIPTION
## PR for other purpose

Fills out our README, updates CONTRIBUTING with some additional information and removes some information from wiki/home that was more suited to being just in the README.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
