### PR TITLE
chore: update to the public GitHub Org name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @OpenJobDescription/Developers

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,1 +1,1 @@
-* @xxyggoqtpcmcofkc/Wiki
+* @OpenJobDescription/Wiki

--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     env:
-        WIKI_REPO: "https://${{ secrets.CI_TOKEN }}@github.com/xxyggoqtpcmcofkc/openjd-specifications.wiki.git"
+        WIKI_REPO: "https://${{ secrets.CI_TOKEN }}@github.com/OpenJobDescription/openjd-specifications.wiki.git"
     steps:
       - uses: actions/checkout@v4
       - name: "Clone wiki contents"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,16 +7,16 @@ Open Job Description is under active development. We're releasing this because w
 as we move forward, together, in defining and implementing a specification that solves the problems in the space. We 
 know that, as currently specified, Open Job Description is not a cure-all for any and all workflows.
 
-* [Discussions](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions): 
+* [Discussions](https://github.com/OpenJobDescription/openjd-specifications/discussions): 
   We encourage you to post about what you would like to see in future revisions of the specification, share, and brag 
   about how you are using Open Job Description, and engage with us and the community.
-* [Request for Comment](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/rfcs/README.md): 
+* [Request for Comment](https://github.com/OpenJobDescription/openjd-specifications/tree/mainline/rfcs/README.md): 
   This repository exists because we want your comments on the specification. Please consider submitting an RFC if you 
   have thoughts on how the specification could be improved.
-* [Issues](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/issues): 
+* [Issues](https://github.com/OpenJobDescription/openjd-specifications/issues): 
   We encourage you to use the GitHub issue tracker to report bugs. 
-* [Pull Requests](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/pulls): 
-  We welcome pull requests to improve this wiki documentation. Simply make your changes in our [GitHub Repository](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/wiki)
+* [Pull Requests](https://github.com/OpenJobDescription/openjd-specifications/pulls): 
+  We welcome pull requests to improve this wiki documentation. Simply make your changes in our [GitHub Repository](https://github.com/OpenJobDescription/openjd-specifications/tree/mainline/wiki)
   and post a pull request.
 
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
@@ -37,7 +37,7 @@ provide your point of view on proposals then we encourage you to engage in this 
 
 See the [RFC Process] README for information on this process.
 
-[RFC process]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/rfcs
+[RFC process]: https://github.com/OpenJobDescription/openjd-specifications/tree/mainline/rfcs
 
 ## Contributing via Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ and to drive updates from the community.
 
 Jump to:
 
-* [Wiki Home](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/wiki)
+* [Wiki Home](https://github.com/OpenJobDescription/openjd-specifications/wiki)
 * [RFC Readme](rfcs/README.md)
 
 ## Getting Started
 
-The fastest way to understand the bones of Open Job Description is to understand both [How Jobs Are Constructed](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/wiki/How-Jobs-Are-Constructed)
-and [How Jobs Are Run](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/wiki/How-Jobs-Are-Run).
+The fastest way to understand the bones of Open Job Description is to understand both [How Jobs Are Constructed](https://github.com/OpenJobDescription/openjd-specifications/wiki/How-Jobs-Are-Constructed)
+and [How Jobs Are Run](https://github.com/OpenJobDescription/openjd-specifications/wiki/How-Jobs-Are-Run).
 
 ## What is Open Job Description?
 
@@ -47,7 +47,7 @@ contribute, and the [RFC Readme](rfcs/README.md) for how to contribute an RFC.
 
 We look forward to your input.
 
-* [Discussions](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions): 
+* [Discussions](https://github.com/OpenJobDescription/openjd-specifications/discussions): 
   We encourage you to post about what you would like to see in future revisions 
   of the specification, share, and brag about how you are using Open Job 
   Description, and engage with us and the community.
@@ -55,16 +55,16 @@ We look forward to your input.
   This repository exists because we want your comments on the specification. 
   Please consider submitting an RFC if you have thoughts on how the 
   specification could be improved.
-* [Issues](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/issues): 
+* [Issues](https://github.com/OpenJobDescription/openjd-specifications/issues): 
   We encourage you to use the GitHub issue tracker to report bugs. 
-* [Pull Requests](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/pulls): 
+* [Pull Requests](https://github.com/OpenJobDescription/openjd-specifications/pulls): 
   We welcome pull requests to improve this wiki documentation. Simply make your 
-  changes in our [GitHub Repository](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/wiki)
+  changes in our [GitHub Repository](https://github.com/OpenJobDescription/openjd-specifications/tree/mainline/wiki)
   and post a pull request.
 
 ## Getting Help
 
-* [Discussions](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions): 
+* [Discussions](https://github.com/OpenJobDescription/openjd-specifications/discussions): 
   Seek help via our GitHub Discussions forum.
 
 ## Security

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -22,8 +22,8 @@ to search through our [issues tracker] and [discussion forum] for similar or com
 proposals. It is possible that your idea has previously been proposed, or it might fit
 in nicely as an enhancement to an RFC that is in the works.
 
-[issues tracker]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/issues
-[discussion forum]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions/categories/ideas
+[issues tracker]: https://github.com/OpenJobDescription/openjd-specifications/issues
+[discussion forum]: https://github.com/OpenJobDescription/openjd-specifications/discussions/categories/ideas
 
 ### 2. Post in GitHub Discussions
 
@@ -35,7 +35,7 @@ to filling out an RFC template with the details of your proposal.
 Simply create a new discussion thread in the [Ideas category] of the discussion forum to
 get started.
 
-[Ideas category]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions/categories/ideas
+[Ideas category]: https://github.com/OpenJobDescription/openjd-specifications/discussions/categories/ideas
 
 ### 3. Tracking Issue
 
@@ -51,7 +51,7 @@ Our [tracking issue template] includes a checklist of all the steps an RFC goes
 through and it's the driver's responsibility to update the checklist and assign
 the correct label to on the RFC throughout the process.
 
-[tracking issue template]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/blob/master/.github/ISSUE_TEMPLATE/rfc.yml
+[tracking issue template]: https://github.com/OpenJobDescription/openjd-specifications/blob/master/.github/ISSUE_TEMPLATE/rfc.yml
 
 ### 4. RFC Document
 
@@ -65,7 +65,7 @@ The next step is to write the first revision of the RFC document itself.
     2. Please follow the template; it includes useful guidance and tips on how to write a good RFC.
 
 [fork this repository]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
-[0000-template.md]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/blob/mainline/rfcs/0000-template.md
+[0000-template.md]: https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0000-template.md
 
 ### 5. Feedback
 
@@ -145,14 +145,14 @@ There are two additional statuses for RFCs that will not move forward:
 - **[Closed](#Closed)** - The RFC was closed by the author, or the review process determined that the proposal will
   not be accepted. The tracking issue and pull request are closed in this stage.
 
-[rfc/proposed]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/labels/rfc%2Fproposed
-[rfc/exploring]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/labels/rfc%2Fexploring
-[rfc/final-comments]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/labels/rfc%2Ffinal-comments
-[rfc/accepted-future]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/labels/rfc%2Faccepted-future
-[rfc/accepted-draft]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/labels/rfc%2Faccepted-draft
-[rfc/accepted-staged]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/labels/rfc%2Faccepted-staged
-[rfc/released]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/labels/rfc%2Freleased
-[rfc/abandoned]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/labels/rfc%2Fabandoned
+[rfc/proposed]: https://github.com/OpenJobDescription/openjd-specifications/labels/rfc%2Fproposed
+[rfc/exploring]: https://github.com/OpenJobDescription/openjd-specifications/labels/rfc%2Fexploring
+[rfc/final-comments]: https://github.com/OpenJobDescription/openjd-specifications/labels/rfc%2Ffinal-comments
+[rfc/accepted-future]: https://github.com/OpenJobDescription/openjd-specifications/labels/rfc%2Faccepted-future
+[rfc/accepted-draft]: https://github.com/OpenJobDescription/openjd-specifications/labels/rfc%2Faccepted-draft
+[rfc/accepted-staged]: https://github.com/OpenJobDescription/openjd-specifications/labels/rfc%2Faccepted-staged
+[rfc/released]: https://github.com/OpenJobDescription/openjd-specifications/labels/rfc%2Freleased
+[rfc/abandoned]: https://github.com/OpenJobDescription/openjd-specifications/labels/rfc%2Fabandoned
 
 ---
 

--- a/wiki/2023-09:-Template-Schemas.md
+++ b/wiki/2023-09:-Template-Schemas.md
@@ -1210,4 +1210,4 @@ This work is licensed under CC BY-ND 4.0. To view a copy of this license, visit 
 
 For more info see the [LICENSE file].
 
-[LICENSE FILE]: https://github.com/xxyggoqtpcmcofkc/openjd-specifications/blob/mainline/LICENSE
+[LICENSE FILE]: https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/LICENSE

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -28,16 +28,16 @@ and [How Jobs Are Run](How-Jobs-Are-Run).
 
 ## Contributing
 
-We want your input! Please see our [Contributing Guidelines](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/blob/mainline/CONTRIBUTING.md) for additional information.
+We want your input! Please see our [Contributing Guidelines](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/CONTRIBUTING.md) for additional information.
 
-* [Discussions](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/discussions): We encourage you to post about what you
+* [Discussions](https://github.com/OpenJobDescription/openjd-specifications/discussions): We encourage you to post about what you
    would like to see in future revisions of the specification, share, and brag about how you are using Open Job Description, and
    engage with us and the community.
-* [Request for Comment](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/rfcs/README.md): This 
+* [Request for Comment](https://github.com/OpenJobDescription/openjd-specifications/tree/mainline/rfcs/README.md): This 
   repository exists because we want your comments on the specification. Please consider submitting an RFC if you have 
   thoughts on how the specification could be improved.
-* [Issues](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/issues): We encourage you to use the GitHub issue tracker
+* [Issues](https://github.com/OpenJobDescription/openjd-specifications/issues): We encourage you to use the GitHub issue tracker
   to report bugs. 
-* [Pull Requests](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/pulls): We welcome pull requests to improve this wiki
-  documentation. Simply make your changes in our [GitHub Repository](https://github.com/xxyggoqtpcmcofkc/openjd-specifications/tree/mainline/wiki)
+* [Pull Requests](https://github.com/OpenJobDescription/openjd-specifications/pulls): We welcome pull requests to improve this wiki
+  documentation. Simply make your changes in our [GitHub Repository](https://github.com/OpenJobDescription/openjd-specifications/tree/mainline/wiki)
   and post a pull request.


### PR DESCRIPTION
All references to the pre-public GitHub organization name need to be updated With the change of the GitHub Organization name to 'OpenJobDescription'. This does that update.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
