### PR TITLE
feat: Add new ASWF OpenJD youtube talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ defining render jobs, or really any type of work suited for completion on a
 render farm, makes tools and plugins portable and increases interoperability.
 
 For deeper insight into our thought process and goals, we recommend
-[this Academy Software Foundation talk](https://www.youtube.com/watch?v=3AM3L6P-cAw&list=PL9dZxafYCWmxDFGc2CEq4SgCkZWKYW1m5&index=14)
-by Pauline Koh, Senior Product Manager at Amazon Web Services, titled
-*Portable Jobs for Open Source Content Production*.
+[this Academy Software Foundation talk](https://www.youtube.com/watch?v=2umfqGX844Y)
+by Pauline Koh, Senior Product Manager - Technical at Amazon Web Services, titled
+*Portable and Open Render Job Specifications*.
 
 ## Open Job Description Projects
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -20,6 +20,10 @@ the space. We know that, as currently specified, Open Job Description is not a c
 
 For deeper insight into our thought process and goals, we recommend [this Academy Software Foundation talk](https://www.youtube.com/watch?v=3AM3L6P-cAw&list=PL9dZxafYCWmxDFGc2CEq4SgCkZWKYW1m5&index=14)
 by Pauline Koh, Senior Product Manager at Amazon Web Services, titled *Portable Jobs for Open Source Content Production*.
+If you want to keep going, [this follow-up talk](https://www.youtube.com/watch?v=2umfqGX844Y), also by Pauline Koh, at 
+the subsequent Academy Software Foundation gathering titled *Portable and Open Render Job Specifications* is a gentle 
+introduction into what you can accomplish with OpenJD. If you've already watched the first talk, you can [start here](https://www.youtube.com/watch?v=2umfqGX844Y&t=383)
+on the second talk.
 
 ## Getting Started
 


### PR DESCRIPTION
Modifies the README and wiki Home to include Pauline's recent talk to the Academy Software Foundation's Open Source Forum 2024, which recaps the previous talk (and thus can be a full replacement for the README) and offers a quick introduction to OpenJD.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.