### PR TITLE
docs: add adaptor runtime to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ submit a pull request.*
 * [openjd-sessions](https://github.com/OpenJobDescription/openjd-sessions-for-python) - A Python
   library that can be used to build a runtime that is able to run Jobs in a Session as defined
   by Open Job Description.
+* [openjd-adaptor-runtime](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python) - A Python library
+  for creating a command-line Adaptor to assist with integrating an existing application, such as a rendering
+  application, into batch computing systems that run Jobs in a way that is compatible with Open Job Description Sessions.
 
 ## Contributing
 


### PR DESCRIPTION
README was missing a link to the openjd-adaptor-runtime-for-python library. This PR adds the description and link to the repo to the README beside the other OpenJD library links.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
