### PR TITLE
feat: Implement a PowerShell example

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -33,6 +33,7 @@ Please see the [CONTRIBUTING guide](../CONTRIBUTING.md) for additional informati
 
 | Environment Template | Concepts Demonstrated |
 | ------ | --------------------- |
+| [powershell-script](./v2023-09/environment_templates/powershell-script.yaml) | environment, calling embedded file with PowerShell |
 | [python-venv](./v2023-09/environment_templates/python-venv.yaml) | environment, openjd_env, embedded file |
 
 ## License

--- a/samples/v2023-09/environment_templates/powershell-script.yaml
+++ b/samples/v2023-09/environment_templates/powershell-script.yaml
@@ -1,0 +1,50 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# ----
+# Demonstrates
+# ----
+# Using an Environment Template to call powershell scripts on Windows
+# Notably this adds the `filename: script.ps1` setting and shows how 
+# to call Powershell correctly.
+#
+# ----
+# Requirements
+# ----
+# - powershell
+#
+# -----
+# Contributors to this template:
+#   Alex Hughes (https://github.com/Ahuge)
+
+specificationVersion: environment-2023-09
+environment:
+  name: PowershellScript
+  description: >
+    Executes a simple powershell script showing correctly how to call it without errors.
+  script:
+    actions:
+      onEnter:
+        # Need to specify the `-File <script>` args for Powershell instead of just passing the `<script>
+        command: powershell
+        args:
+            - "-File"
+            - "{{Env.File.Enter}}"
+      onExit:
+        command: powershell
+        args:
+            - "-File"
+            - "{{Env.File.Exit}}"
+    embeddedFiles:
+    - name: Enter
+      type: TEXT
+      # Required to name our powershell script a name that ends with ".ps1"
+      # See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_scripts?view=powershell-7.4#long-description
+      filename: enter.ps1
+      data: |
+        Write-Output "Powershell Enter"
+        echo "openjd_env: ENVIRONMENT_VARIABLE=ENVIRONMENT_VALUE"
+    - name: Exit
+      type: TEXT
+      filename: exit.ps1
+      data: |
+        Write-Output "Powershell Exit"


### PR DESCRIPTION
This example shows an environment script that calls a PowerShell script onEnter and onExit.

This shows the required `-File <script>` arguments as well as the `filename: script.ps1` naming requirement so that our PowerShell script can be executed by PowerShell.


*Please choose the format that best matches the purpose of this pull request. Delete the top-level header of the chosen
section as well as all other sections.*

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
