### PR TITLE
feat(wiki): disambiguate amount.worker.gpu.memory for multi-GPU hosts

### DIFF
--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -551,7 +551,7 @@ users to define their own custom capabilities.
 |amount.worker.vcpu        |1|A number of vCPUs/CPU-cores available on the host.|
 |amount.worker.memory      |0|An amount of system memory available on the host. Units: MiB. |
 |amount.worker.gpu         |0|A number of GPUs available on the host.|
-|amount.worker.gpu.memory  |0|An amount of memory available in GPUs on the host. Units: MiB.|
+|amount.worker.gpu.memory  |0|The lower bound of total memory provided by each GPU on the host. For example, if a host has one GPU with 4096 and one GPU with 2048, this value would be 2048. Units: MiB.|
 |amount.worker.disk.scratch|0|A static amount of disk storage installed on the host for use as scratch space. Units: GiB.|
 
 #### 3.3.2. `<AttributeRequirement>`


### PR DESCRIPTION
## Problem

Fixes #50.

## Solution

Formalize how render management systems should aggregate `amount.worker.gpu.memory` in the case of a multi-GPU host.

The choice was to take the lower bound of memory across all GPUs on the host. All choices of aggregation (total/min/max/average) have pros and cons. Ultimately, the proposed formalization here is based on the assumptions:

1.  most existing GPU workloads leverage a single GPU
2. when specifying a step's host requirements, job template authors will more often intuitively assume this is referring to a single GPU's total memory. 

In future OpenJD spec versions, OpenJD can standardize additional aggregations (e.g. `amount.worker.gpu.totalMemory` or `amount.worker.gpu.maxMemory`) if there is sufficient interest.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
