### PR TITLE
feat: Merge RFC 0001 into the 2023-09 template schema wiki

### DIFF
--- a/rfcs/0001-task-chunking.md
+++ b/rfcs/0001-task-chunking.md
@@ -3,7 +3,7 @@
 * RFC Tracking Issue: https://github.com/OpenJobDescription/openjd-specifications/issues/53
 * Start Date: 2024-11-27
 * Specification Version: 2023-09 extension TASK_CHUNKING
-* Accepted On: in draft
+* Accepted On: 2025-01-17
 * Depends On: RFC 0002 (https://github.com/OpenJobDescription/openjd-specifications/issues/57)
 
 ## Summary

--- a/rfcs/0002-model-extensions.md
+++ b/rfcs/0002-model-extensions.md
@@ -2,25 +2,25 @@
 * Feature Name: Model Extensions
 * RFC Tracking Issue: https://github.com/OpenJobDescription/openjd-specifications/issues/66
 * Start Date: 2024-12-09
-* Accepted On: in draft
+* Accepted On: 2025-01-17
 
 ## Summary
 
-This RFC proposes a method of enabling additional approved functionality that is not included in 
- a specific version of the model release through a new top level job template key `Extensions`.  
+This RFC proposes a method of enabling additional approved functionality that is not included in
+ a specific version of the model release through a new top level job template key `Extensions`.
 Each extension is similar to the `from __future__` import system in Python <sup>[python.org](https://docs.python.org/3/library/__future__.html)</sup> .
 
-Because these extensions are optional, each scheduler can support any or all of these features. 
+Because these extensions are optional, each scheduler can support any or all of these features.
 This allows for schedulers to add support and prepare for future openjd-specification releases gradually.
-  
+
 ## Basic Examples
 
 ### Example Job Template
 
-The following job template is built on the 2023-09 version of the specification but requests support for 
-Task Chunking (from [RFC-0001](https://github.com/OpenJobDescription/openjd-specifications/pull/54)).  
-  
-The `extensions` key is a list of extensions that the job template author has determined are required. 
+The following job template is built on the 2023-09 version of the specification but requests support for
+Task Chunking (from [RFC-0001](https://github.com/OpenJobDescription/openjd-specifications/pull/54)).
+
+The `extensions` key is a list of extensions that the job template author has determined are required.
 
 ```yaml
 specificationVersion: 'jobtemplate-2023-09'
@@ -69,33 +69,33 @@ steps:
 
 
 ## Motivation
-During a discussion on [RFC-0001](https://github.com/OpenJobDescription/openjd-specifications/pull/54), it was determined that a 
-way was required to publish any new functionality that an RFC may provide.  
+During a discussion on [RFC-0001](https://github.com/OpenJobDescription/openjd-specifications/pull/54), it was determined that a
+way was required to publish any new functionality that an RFC may provide.
 
 
-Initial discussions centered around the idea of incrementing the job template specification version each time an RFC was approved, 
-however that rapid release schedule posed a few issues.  
-When an OpenJD Specification release is approved, there is a level of continued support that is expected. If a OpenJD Specification is 
-released every time an RFC is approved, there may be dozens of individual versions that all need to be fully supported by schedulers. 
-If releases of OpenJD specifications are planned and scheduled, extensions can be treated as requesting an optional feature. 
-That should allow less churn and code management for the OpenJD implementations.  
-Another issue came up when the code implementation was considered. Currently there exists a single version of the OpenJD for Python 
-implementation. As new OpenJD Specifications are released this implementation, both the model and the sessions libraries, will have 
-to either branch supported releases or manage multiple versions of the codebase in a single repository.   
-Anything that the OpenJD Specification team can do to lessen their management burden will be appreciated.  
+Initial discussions centered around the idea of incrementing the job template specification version each time an RFC was approved,
+however that rapid release schedule posed a few issues.
+When an OpenJD Specification release is approved, there is a level of continued support that is expected. If a OpenJD Specification is
+released every time an RFC is approved, there may be dozens of individual versions that all need to be fully supported by schedulers.
+If releases of OpenJD specifications are planned and scheduled, extensions can be treated as requesting an optional feature.
+That should allow less churn and code management for the OpenJD implementations.
+Another issue came up when the code implementation was considered. Currently there exists a single version of the OpenJD for Python
+implementation. As new OpenJD Specifications are released this implementation, both the model and the sessions libraries, will have
+to either branch supported releases or manage multiple versions of the codebase in a single repository.
+Anything that the OpenJD Specification team can do to lessen their management burden will be appreciated.
 
-The idea of treating these RFC functionality as [Python \_\_future__](https://docs.python.org/3/library/__future__.html) 
-imports was determined to be the best way forward so that this newly approved functionality can be utilized on schedulers as 
+The idea of treating these RFC functionality as [Python \_\_future__](https://docs.python.org/3/library/__future__.html)
+imports was determined to be the best way forward so that this newly approved functionality can be utilized on schedulers as
 they add support for it without requiring a full specification release to be approved and implemented.
-  
-### Supported Extensions
-Valid values for the `extensions` key must still be approved and implemented through the standard RFC process in the 
-openjd-specifications repository.  
-These approved RFCs can define breaking functionality as an extension and have schedulers add support for them before a 
-new formal specification release.  
 
-These extensions should be treated as requests to the scheduler and job template authors should be aware that a 
-specific scheduler may reject a job template submission if it does not support all of the required extensions.    
+### Supported Extensions
+Valid values for the `extensions` key must still be approved and implemented through the standard RFC process in the
+openjd-specifications repository.
+These approved RFCs can define breaking functionality as an extension and have schedulers add support for them before a
+new formal specification release.
+
+These extensions should be treated as requests to the scheduler and job template authors should be aware that a
+specific scheduler may reject a job template submission if it does not support all of the required extensions.
 
 Each individual scheduler may want to enable extensions either as early access preview features or behind feature flags.
 The scheduler may also want to roll out support for individual extensions after they have been fully testing and support has been verified.
@@ -103,26 +103,26 @@ The scheduler may also want to roll out support for individual extensions after 
 ### Merging Extensions
 This proposal also defines the process for merging Extensions into the next version of the model release.
 
-A new subsection of the RFC template is defined under `Specification` called `Extension Name`.  
-If a specific RFC adds or breaks functionality in the base model, it should define an Extension Name that can be used 
-to reference the functionality in openjd implementations.  
-This name should match the regex: `[A-Z0-9_]{3,128}`.  
+A new subsection of the RFC template is defined under `Specification` called `Extension Name`.
+If a specific RFC adds or breaks functionality in the base model, it should define an Extension Name that can be used
+to reference the functionality in openjd implementations.
+This name should match the regex: `[A-Z0-9_]{3,128}`.
 
 #### Updating Extensions
-There may be scenarios where an extension that is destined for release in a future specification release needs 
-additional modifications before merging in to the release.  
+There may be scenarios where an extension that is destined for release in a future specification release needs
+additional modifications before merging in to the release.
 Reasons for this may include:
    - After widespread adoption the feature doesn't fulfill its design goals
  - A separate RFC implements the functionality in a more succinct way
 
-   
-You may name the extension with a numerical suffix, for example `TASK_CHUNKING_2` to indicate it supercedes an already approved extension.  
-Schedulers can choose to continue support for the original extension, or only support the new implementation.  
 
-These "superceding extensions" are expected to get merged into a future specification release instead of the initial one.  
-  
-If an extension is updating functionality that already exists in a version of the specification, the numerical suffixing is not required..  
-> Extension names are only required to be unique within a specification version, however it is best practice to keep them globally unique to reduce confusion.  
+You may name the extension with a numerical suffix, for example `TASK_CHUNKING_2` to indicate it supercedes an already approved extension.
+Schedulers can choose to continue support for the original extension, or only support the new implementation.
+
+These "superceding extensions" are expected to get merged into a future specification release instead of the initial one.
+
+If an extension is updating functionality that already exists in a version of the specification, the numerical suffixing is not required..
+> Extension names are only required to be unique within a specification version, however it is best practice to keep them globally unique to reduce confusion.
 
 
 
@@ -132,21 +132,21 @@ An extension consists of the following information:
 - An array of Literal `specificationVersion` strings that the extension states that it works with, ie [`jobtemplate-2023-09`, `jobtemplate-2025-03`]
 
 
-### Releasing A Specification Version  
-When a new version of the specification is released, all accepted extension names from the previous release are labeled as 
+### Releasing A Specification Version
+When a new version of the specification is released, all accepted extension names from the previous release are labeled as
 deprecated and may still be used but are treated as a NoOp.
-Schedulers are encouraged to notify their users that they are using a deprecated extension which is enabled by default.  
+Schedulers are encouraged to notify their users that they are using a deprecated extension which is enabled by default.
 
-Any extensions that were not accepted in the release are considered obsolete and schedulers should return an error if a 
-job template is using an obsoleted extension 
+Any extensions that were not accepted in the release are considered obsolete and schedulers should return an error if a
+job template is using an obsoleted extension
 
-Any deprecated extensions from the previous specification release are now also considered obsolete and should be 
-treated the same as non-accepted extensions.  
+Any deprecated extensions from the previous specification release are now also considered obsolete and should be
+treated the same as non-accepted extensions.
 
 A released specification will have the following:
-- A list of extensions that were merged into the release (deprecated extensions).  
-- A list of extensions that were marked as deprecated in the previous release (which are now obsolete and return an error if used).  
-- A list of currently known extensions inherited from the previous release. This list will grow as new RFCs are approved.  
+- A list of extensions that were merged into the release (deprecated extensions).
+- A list of extensions that were marked as deprecated in the previous release (which are now obsolete and return an error if used).
+- A list of currently known extensions inherited from the previous release. This list will grow as new RFCs are approved.
 
 
 
@@ -171,7 +171,7 @@ A released specification will have the following:
 
 ```diff
 + #### 1.1.2. `<ExtensionName>`
-+ 
++
 + A literal string matching the following character regex: [A-Z_0-9]{3,128}.
 ```
 
@@ -179,22 +179,22 @@ A released specification will have the following:
 
 ### Gradual Feature Support
 
-By enabling functionality as feature flag style options, schedulers can adopt functionality that is aim for future 
-specification releases and increase adoption and testing of these features before they get ratified in specification 
-versions that need to have continued support.  
+By enabling functionality as feature flag style options, schedulers can adopt functionality that is aim for future
+specification releases and increase adoption and testing of these features before they get ratified in specification
+versions that need to have continued support.
 
 
 ### Reduced Specification Release Overhead
 
-By introducing a way to get functionality deployed and tested before ratifying it in a specification release, the hope is that there 
+By introducing a way to get functionality deployed and tested before ratifying it in a specification release, the hope is that there
 will be less need for immediate specification version releases.
 When a new version is released, the newly merged in functionality is fully baked and has been tested by a wider audience.
 
 ## Prior Art
 
-This RFC takes inspiration from the `__future__` import system in Python <sup>[python.org](https://docs.python.org/3/library/__future__.html)</sup> and the [`AWS::LanguageExtensions`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-languageextensions.html) feature in Cloudformation.  
+This RFC takes inspiration from the `__future__` import system in Python <sup>[python.org](https://docs.python.org/3/library/__future__.html)</sup> and the [`AWS::LanguageExtensions`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-languageextensions.html) feature in Cloudformation.
 
-The [OpenGL_Extension](https://www.khronos.org/opengl/wiki/OpenGL_Extension) system is also a good piece of prior art to look at for inspiration.  
+The [OpenGL_Extension](https://www.khronos.org/opengl/wiki/OpenGL_Extension) system is also a good piece of prior art to look at for inspiration.
 They implement define vendor extensions and a review board to help merge extensions into OpenGL core
 
 ## Rejected Ideas
@@ -202,7 +202,7 @@ They implement define vendor extensions and a review board to help merge extensi
 ### Release a new specification release for each RFC
 
 Initial thoughts around releasing a new specification version for each RFC approved quickly became overwhelming.
-This became obvious when determining the strategies we would use to manage codebases, supported versions etc.  
+This became obvious when determining the strategies we would use to manage codebases, supported versions etc.
 
 Some questions that came up during industry discussions were:
 - When submitting to a scheduler, would a user expect every specification release to be supported? Only the latest number of versions?
@@ -210,17 +210,17 @@ Or is that up to the scheduler?
 - For code based implementations of OpenJD, do they need to support multiple major version releases corresponding to each specification
 release and would that conflict with the semVer versioning requirements by these implementations?
 - What would happen if a user submitted a job template with an older specification version, is it expected that the scheduler will try
-running it in a newer model or would a user expect it to fail on submission? 
+running it in a newer model or would a user expect it to fail on submission?
 
-Many of these questions become easier if OpenJD Specification release schedules are slowed down.  
+Many of these questions become easier if OpenJD Specification release schedules are slowed down.
 In those cases the OpenJD specification team could recommend support for "the last X releases" which may end up supporting several years
-of specification version as opposed to a potentially shorter window if release schedules become ad-hoc.  
+of specification version as opposed to a potentially shorter window if release schedules become ad-hoc.
 
 
 ## Further Discussion
 
-Further discussion is needed on OpenJD Specification release schedules, processes for merging RFC extensions into newer releases of the specification, and actual implementation of RFC extensions.  
-These discussions can be started in the pull-request comment section and the RFC will be updated accordingly.  
+Further discussion is needed on OpenJD Specification release schedules, processes for merging RFC extensions into newer releases of the specification, and actual implementation of RFC extensions.
+These discussions can be started in the pull-request comment section and the RFC will be updated accordingly.
 
 ## Copyright
 

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -22,6 +22,8 @@ Notations used in this document to annotate aspects of the schema definition:
    * `@fmtstring[host]` - The value is evaluated at runtime on the worker host on which the job is running. The value is otherwise
      evaluated when the job template is submitted and the render manager is constructing a job.
 * `@optional` - The annotated property is optional.
+* `@extension EXTENSION_NAME` - The annotated property is available only when extension EXTENSION_NAME is requested
+  in the `extensions` list of the template. Implementations can choose which extensions to support.
 
 ## 1. Root elements
 
@@ -645,8 +647,11 @@ Where:
 Definition of a single task parameter; its name, type, and the range of values that it takes.
 
 ```bnf
-<TaskParameterDefinition> ::= <IntTaskParameterDefinition> | <FloatTaskParameterDefinition> |
-                              <StringTaskParameterDefinition> | <PathTaskParameterDefinition>
+<TaskParameterDefinition> ::= <IntTaskParameterDefinition> |
+                              <FloatTaskParameterDefinition> |
+                              <StringTaskParameterDefinition> |
+                              <PathTaskParameterDefinition> |
+                              <ChunkIntTaskParameterDefinition> # @extension TASK_CHUNKING
 ```
 
 ##### 3.4.1.1. `<IntTaskParameterDefinition>`
@@ -801,6 +806,46 @@ using the following names:
 1. `Task.Param.<name>` — the value of the parameter with relevant path mapping rules applied to it; and
 2. `Task.RawParam.<name>` — the value of the parameter as it was defined, with no path mapping rules applied.
 
+##### 3.4.1.5. `<ChunkIntTaskParameterDefinition>` `# @extension TASK_CHUNKING`
+
+An integer valued task parameter, processed as chunks instead of as individual elements.
+A `<ChunkIntTaskParameterDefinition>` is the object:
+
+```yaml
+  name: <Identifier>
+  type: "CHUNK[INT]"
+  range: <IntRangeList> | <IntRangeExpr>
+  chunks:
+    defaultTaskCount: <integer> | <intstring> # @fmtstring
+    targetRuntimeSeconds: <integer> | <intstring> # @optional @fmtstring
+    rangeConstraint: "CONTIGUOUS" | "NONCONTIGUOUS"
+```
+
+See section `<IntTaskParameterDefinition>` for the definitions of `<IntRangeExpr>` and `<intstring>`.
+
+1. *name* — The name of the parameter.
+2. *type* — The literal "CHUNK[INT]", defining this parameter as integer valued and processed
+    as chunks.
+3. *range* — The list of values that the parameter takes on to define Tasks of the Step.
+4. *chunks* — Specifies how to form sets of values into chunks.
+    1. *defaultTaskCount* — How many tasks to combine into a single chunk by default.
+    2. *targetRuntimeSeconds* — If provided, the number of seconds to aim for when forming chunks.
+        A scheduler can ignore this, or dynamically adjust the chunk task count to be closer
+        to this value once some chunks have completed.
+    3. *rangeConstraint* — If CONTIGUOUS, a chunk must always be a contiguous range
+        of integers with two integers separated by "-" like a single "5-5" or interval "1-10".
+        If NONCONTIGUOUS, a chunk can be an arbitrary set of integers following the
+        `<IntRangeExpr>` syntax like "1,3,7-10:2".
+5. `<IntRangeList>` is subject to the constraints:
+   * Minimum number of elements: If provided, then this list must contain at least one element.
+   * Maximum number of elements: The list must not contain more than 1024 elements.
+
+The value of a task parameter of this type can be referenced in format strings that will be evaluated when running a Task
+using the following names:
+
+1. `Task.Param.<name>` and
+2. `Task.RawParam.<name>`
+
 #### 3.4.2. `<TaskParameterStringValue>`
 
 A [Format String](#73-format-strings) subject to the following constraints:
@@ -830,6 +875,9 @@ Subject to the following constraints:
    exactly once in the entire expression.
 5. Every comma-separated expression within an associative operator must have the exact same number of values defined
    in their range.
+6. If a task parameter is chunked, for example it has type `CHUNK[INT]`, it must not be
+   combined with any other task parameter using the associative operator. For example if
+   `A` is chunked, then `A * B` is permitted but `(A, B)` is an error.
 
 For example, given the four Task Parameters named "A", "B", "C", and "D" with values:
 
@@ -850,6 +898,14 @@ The following table lists some expressions and the resulting parameter space.
 |(A,B,D)   |(A=1,B=10,D=a), (A=2,B-11,D=b), (A=3,B=10,D=c)|
 |(A,C)     |Error: length mismatch (A and C have differing numbers of values)|
 |(A,B,A)   |Error: each parameter may only appear once in the expression.|
+
+If `A` has type `CHUNK[INT]`, the parameter space is the same as if it had type `INT`,
+but each chunk provided to the `onRun` action specifies an integer range expression for
+`A` instead of a single value. The scheduler might select the following chunks when
+`rangeConstraint` is set to `CONTIGUOUS`:
+
+(A="1-1", B=10), (A="2-2", B=10), (A="3-3", B=10),
+(A="1-2", B=11), (A="3-3", B=11), (A="1-3", B=12)
 
 ### 3.5. `<StepScript>`
 

--- a/wiki/How-Jobs-Are-Constructed.md
+++ b/wiki/How-Jobs-Are-Constructed.md
@@ -1,26 +1,30 @@
 # How Jobs Are Constructed
 
-A **Job** in Open Job Description is a delineation of a workflow that is submitted to a render management system. 
+A **Job** in Open Job Description is a delineation of a workflow that is submitted to a render management system.
 The **Job** is, ultimately, a set of commands that are run on **Worker Hosts** subject to ordering, parallelism,
-and other hardware and scheduling constraints. A **Job** in this specification is defined via a **Job Template**. The 
-**Job Template** describes the shape of a **Job**, its runtime environment, and the processes that will run. The 
+and other hardware and scheduling constraints. A **Job** in this specification is defined via a **Job Template**. The
+**Job Template** describes the shape of a **Job**, its runtime environment, and the processes that will run. The
 benefits of using a templated approach to creating jobs include:
 
 1. **User-facing Parameters**
    * A single **Job Template** with user-facing parameters can be used to create multiple Jobs in a render management
      system that all perform the same actions on different inputs.
-2. **Model complex workflows** 
-   * The **Job Template** defines a set of **Steps** that each define a parameterized process to run; like an image 
+2. **Model complex workflows**
+   * The **Job Template** defines a set of **Steps** that each define a parameterized process to run; like an image
      render, file conversion, or video file encoding.
-   * Dependencies added between **Steps** can control the execution order. For example, adding dependencies can ensure 
+   * Dependencies added between **Steps** can control the execution order. For example, adding dependencies can ensure
      that all the frames of an image sequence have been rendered before the video file encoding **Step** is run. If
      dependencies are not added, **Steps** are free to run in parallel.
-   * Each **Step** is stamped out to one or more **Tasks** through the **Step**'s parameterization. **Tasks** are the 
-     exact unit of work that a render management system schedules to its **Worker Hosts**. For example, a stereoscopic 
-     render **Step** can be parameterized on the frame number and the left/right camera choice. Each combination of a 
+   * Each **Step** is stamped out to one or more **Tasks** through the **Step**'s parameterization. **Tasks** are the
+     exact unit of work that a render management system schedules to its **Worker Hosts**. For example, a stereoscopic
+     render **Step** can be parameterized on the frame number and the left/right camera choice. Each combination of a
      frame number with a camera choice produces a single **Task**.
+        * When the TASK_CHUNKING extension is used, **Tasks** can be grouped together into a **Chunk** consisting
+          of a set of values for a Task parameter of type `CHUNK[INT]`. The **Chunk** is then scheduled as a single
+          action, and the step script can choose whether to run those tasks serially or
+          in parallel on multiple cores.
 3. **Host Scheduling Requirements**
-   * Which **Worker Hosts** **Tasks** can be scheduled to can be controlled by specifying **Worker Host** resources and 
+   * Which **Worker Hosts** **Tasks** can be scheduled to can be controlled by specifying **Worker Host** resources and
      properties that each **Step** requires.
       * Quantifiable requirements such as amount of memory, and the number of CPU cores.
       * Attribute requirements such as the operating system, CPU architecture, or software.
@@ -32,59 +36,59 @@ benefits of using a templated approach to creating jobs include:
 ## Job Structure
 
 Consider the following diagram of a **Job** that demonstrates the relationships between the components described above.
-The lefthand side of the diagram shows a **Job Template**, and the right-hand side shows a **Job** that is created from 
-that **Job Template**. 
+The lefthand side of the diagram shows a **Job Template**, and the right-hand side shows a **Job** that is created from
+that **Job Template**.
 
 ![Job Structure](./images/job_structure.png)
 
-A **Job** is created via a **Job Template** which is a [JSON](https://www.json.org/json-en.html) or [YAML](https://yaml.org/) 
-document that outlines the shape of the **Job**; what the parameterization of the **Job** is, and what its **Steps** are. 
-To create a **Job** you provide both a **Job Template** and a set of values for the **Job Parameters** defined in the 
-**Job Template**. This example has a single integer valued **Job Parameter** named `End` that was given the value 400 
-when the **Job** was created, but would otherwise have defaulted to the value of `1000` if not provided. The render 
+A **Job** is created via a **Job Template** which is a [JSON](https://www.json.org/json-en.html) or [YAML](https://yaml.org/)
+document that outlines the shape of the **Job**; what the parameterization of the **Job** is, and what its **Steps** are.
+To create a **Job** you provide both a **Job Template** and a set of values for the **Job Parameters** defined in the
+**Job Template**. This example has a single integer valued **Job Parameter** named `End` that was given the value 400
+when the **Job** was created, but would otherwise have defaulted to the value of `1000` if not provided. The render
 management system then uses the provided **Job Parameter** values to instantiate the **Job** from the **Job Template**.
 
-Each **Step** in a **Job** defines a specific action to perform, the parameter space of values over which the command 
-will be run, and the constraints under which the **Step** may run. Constraints include required **Worker Host** 
-properties and which, if any, **Step(s)** in the same **Job** must be completed before the **Step**'s **Tasks** can be 
-run. All **Steps** have a unique name within the **Job** (`"HelloWorld"` in this example) that is used within the 
-**Job Template** to refer to the Step. For example, a **Step** is referred to by name when declaring it as a dependency 
+Each **Step** in a **Job** defines a specific action to perform, the parameter space of values over which the command
+will be run, and the constraints under which the **Step** may run. Constraints include required **Worker Host**
+properties and which, if any, **Step(s)** in the same **Job** must be completed before the **Step**'s **Tasks** can be
+run. All **Steps** have a unique name within the **Job** (`"HelloWorld"` in this example) that is used within the
+**Job Template** to refer to the Step. For example, a **Step** is referred to by name when declaring it as a dependency
 of another **Step**.
 
-The parameterized action performed by a **Step** is called the **Step Script**. The **Step Script** consists of a 
-command-line command to run, and a set of optional embedded files that can include the contents of a text file (shell 
-script, python script, json document, etc.) within the definition of the **Step** rather than on a shared medium such 
-as a filesystem. 
+The parameterized action performed by a **Step** is called the **Step Script**. The **Step Script** consists of a
+command-line command to run, and a set of optional embedded files that can include the contents of a text file (shell
+script, python script, json document, etc.) within the definition of the **Step** rather than on a shared medium such
+as a filesystem.
 
 The **Task** is the unit of schedulable work run on **Worker Hosts** within the render management system. **Tasks** are
 broken out from the **Step** according to their specific values for each of the **Task Parameters**, and each **Task**
-then runs the action that is defined in the **Step** it belongs to. These specific parameter values are defined by the 
-**Step**'s **Parameter Space**; the names, types, and values of each of the **Task Parameters**, in addition to how 
-those **Task Parameters** are combined in to a multidimensional parameter space. In this example, we have a 
+then runs the action that is defined in the **Step** it belongs to. These specific parameter values are defined by the
+**Step**'s **Parameter Space**; the names, types, and values of each of the **Task Parameters**, in addition to how
+those **Task Parameters** are combined in to a multidimensional parameter space. In this example, we have a
 **Parameter Space** that consists of the values such as `{"Frame": 1, "Camera": "top"}`, `{"Frame": 1, "Camera": "left"}`,
-`{"Frame": 1, "Camera": "right"}`, `{"Frame": 1, "Camera": "bottom"}`, `{"Frame": 11, "Camera": "top"}`, with `"Frame"` 
+`{"Frame": 1, "Camera": "right"}`, `{"Frame": 1, "Camera": "bottom"}`, `{"Frame": 11, "Camera": "top"}`, with `"Frame"`
 and `"Camera"` being the names of the two **Task Parameters**.
 
 ## Format Strings
 
-**Format Strings** are templated strings that can reference values such as job parameter values, the location of the 
-**Session** working directory, etc. These strings may contain one or more **String Interpolation Expressions** that are 
-resolved before the string's value is used. A **String Interpolation Expression** within a **Format String** is denoted 
-by a double-pair of open and closing curly braces as in: `"The location of the Session Working directory is {{ Session.WorkingDirectory }}"`. 
-You can also see usages of **Format Strings** within the example in the previous section. 
+**Format Strings** are templated strings that can reference values such as job parameter values, the location of the
+**Session** working directory, etc. These strings may contain one or more **String Interpolation Expressions** that are
+resolved before the string's value is used. A **String Interpolation Expression** within a **Format String** is denoted
+by a double-pair of open and closing curly braces as in: `"The location of the Session Working directory is {{ Session.WorkingDirectory }}"`.
+You can also see usages of **Format Strings** within the example in the previous section.
 
-The **String Interpolation Expression** must contain a single value reference (see [Value References](#value-references)), 
-but a **Format String** may contain many **String Interpolation Expressions**. The **Format String** is resolved by 
-replacing the open & closing curly braces and everything within them with the referenced value. For example, the range 
-value, `"1-{{ Param.End}}:10"`, for the "Frame" **Task Parameter** in the previous section's example resolves to 
-`"1-400:10"` when the **Job Template** is evaluated with `End=400`. 
+The **String Interpolation Expression** must contain a single value reference (see [Value References](#value-references)),
+but a **Format String** may contain many **String Interpolation Expressions**. The **Format String** is resolved by
+replacing the open & closing curly braces and everything within them with the referenced value. For example, the range
+value, `"1-{{ Param.End}}:10"`, for the "Frame" **Task Parameter** in the previous section's example resolves to
+`"1-400:10"` when the **Job Template** is evaluated with `End=400`.
 
-The time when a **Format String** in a **Job Template** is evaluated is determined by what value from the **Job Template** 
-is being defined. For example, the string `"1-{{Param.End}}:10"` in the previous section's example is evaluated by the 
-render management system when the **Job Template** is submitted to create a **Job**, and the string 
-`"{{ Task.File.Foo }}"` is evaluated on the **Worker Host** when running a **Task**. You can see when a **Format String** is 
-evaluated in the [job template specification](2023-09-Template-Schemas), but the general rule of thumb is that values 
-that are used on the **Worker Host** to run a command are evaluated on the **Worker Host** and all others are evaluated 
+The time when a **Format String** in a **Job Template** is evaluated is determined by what value from the **Job Template**
+is being defined. For example, the string `"1-{{Param.End}}:10"` in the previous section's example is evaluated by the
+render management system when the **Job Template** is submitted to create a **Job**, and the string
+`"{{ Task.File.Foo }}"` is evaluated on the **Worker Host** when running a **Task**. You can see when a **Format String** is
+evaluated in the [job template specification](2023-09-Template-Schemas), but the general rule of thumb is that values
+that are used on the **Worker Host** to run a command are evaluated on the **Worker Host** and all others are evaluated
 in the render management system.
 
 ### Value References

--- a/wiki/How-Jobs-Are-Run.md
+++ b/wiki/How-Jobs-Are-Run.md
@@ -4,33 +4,37 @@ Before reading this we recommend diving into [How Jobs Are Constructed](How-Jobs
 
 ## Sessions
 
-Open Job Description's Tasks are run within the context of a **Session**. A **Session** is an ephemeral runtime 
-environment on a Worker Host created to run a set of Tasks from the same Job, and is destroyed when the Worker Host is 
-done running Tasks for that Job. The **Session** provides a way for you to customize the environment that your Tasks 
-run within, such as defining a shared set of environment variables or starting a container to run Tasks. Allowing 
+Open Job Description's Tasks are run within the context of a **Session**. A **Session** is an ephemeral runtime
+environment on a Worker Host created to run a set of Tasks from the same Job, and is destroyed when the Worker Host is
+done running Tasks for that Job. The **Session** provides a way for you to customize the environment that your Tasks
+run within, such as defining a shared set of environment variables or starting a container to run Tasks. Allowing
 multiple tasks to execute within the same **Session** **Environment** also allows for costly set up and tear down operations
 to be used for multiple Tasks, resulting in more efficient job execution. This additionally allows for operations like
 installing software or downloading files to the host.
 
-A temporary **Working Directory** is created on the Worker Host for each **Session**, and deleted once all the Tasks 
-within that session have completed running, any **Environments** exited, and the **Session** terminated. The 
-**Working Directory** is available as scratch space for the Tasks running within the **Session**, which enables things 
+A temporary **Working Directory** is created on the Worker Host for each **Session**, and deleted once all the Tasks
+within that session have completed running, any **Environments** exited, and the **Session** terminated. The
+**Working Directory** is available as scratch space for the Tasks running within the **Session**, which enables things
 like sharing data between Tasks.
 
 A Job and/or Step can define zero or more **Environments** that must be entered in a defined order at the start of
-a **Session** prior to running any Tasks, and exited in the reverse order prior to terminating the **Session**. An 
-**Environment** defines **Actions**, command-lines with arguments, to run when it is entered or exited, and may also 
+a **Session** prior to running any Tasks, and exited in the reverse order prior to terminating the **Session**. An
+**Environment** defines **Actions**, command-lines with arguments, to run when it is entered or exited, and may also
 define a set of environment variable values that become available in all subsequent **Actions** run in the **Session**
 until the **Environment** is exited.
 
-Once the **Environments** have been created and entered for a **Session**, a series of Tasks are run within that 
-**Session** and the **Environments**. Tasks from any Step in a Job can run within the same **Session** provided that 
-the set of **Environments** that are required to run those Tasks are identical.
+Once the **Environments** have been created and entered for a **Session**, a series of Tasks are run within that
+**Session** and the **Environments**. Tasks from any Step in a Job can run within the same **Session** provided that
+the set of **Environments** that are required to run those Tasks are identical. If the parameter space of a Step
+includes a task parameter with type `CHUNK[INT]` (part of the TASK_CHUNKING extension), then the **Session**
+runs Chunks for that Step instead of individual Tasks. A Chunk is a set of Tasks with all of the Task parameter
+values identical except for the chunked Task parameter. It takes values from an integer range expression
+like "1-3" or 1-3,5,7" depending on whether the chunks are constrained to be contiguous or not.
 
-All failures and cancellations in a **Session** are terminal for the **Session**, as the system generally does not know 
-what state a failure or cancellation leaves the **Session** in. Think of a Task failure which inadvertently terminates 
-the container that was set up in an **Environment** for the Tasks to run 
-within. A failed Task will result in a failed **Session**, which will subsequently exit all **Environments** that the 
+All failures and cancellations in a **Session** are terminal for the **Session**, as the system generally does not know
+what state a failure or cancellation leaves the **Session** in. Think of a Task failure which inadvertently terminates
+the container that was set up in an **Environment** for the Tasks to run
+within. A failed Task will result in a failed **Session**, which will subsequently exit all **Environments** that the
 **Session** entered or attempted to enter, and then be terminated itself.
 
 The following diagram provides an overview of the steps taken to run a Session.
@@ -39,43 +43,43 @@ The following diagram provides an overview of the steps taken to run a Session.
 
 ## Host Requirements
 
-Open Job Description provides a mechanism for a Step to impose requirements that must be satisfied for Tasks from the 
-Step to be scheduled. Each requirement corresponds to an attribute of a Worker Host or render manager that must be 
-satisfied to allow the Step to be scheduled to the Worker Host. Some examples of concrete attributes include 
-processor architecture (x86_64, arm64, etc.), the number of CPU cores, the amount of system memory, or available 
-floating licenses for an application. We also allow for user-defined requirements whose meaning is specified by the 
+Open Job Description provides a mechanism for a Step to impose requirements that must be satisfied for Tasks from the
+Step to be scheduled. Each requirement corresponds to an attribute of a Worker Host or render manager that must be
+satisfied to allow the Step to be scheduled to the Worker Host. Some examples of concrete attributes include
+processor architecture (x86_64, arm64, etc.), the number of CPU cores, the amount of system memory, or available
+floating licenses for an application. We also allow for user-defined requirements whose meaning is specified by the
 user; a `“SoftwareConfig”` requirement whose values could be `“Option1”` or `“Option2”`, for example.
 
 There are two types of requirements: amount and attribute.
 
 Amount requirements are the mechanism for defining a quantity of something that the Worker Host or render manager needs
-for a Step to run. They represent quantifiable things that must be reserved — vCPUs, memory, licenses, etc. They are 
-always a non-negative floating point value, and a Step can require a certain amount of that capability, “at least 4 CPU 
+for a Step to run. They represent quantifiable things that must be reserved — vCPUs, memory, licenses, etc. They are
+always a non-negative floating point value, and a Step can require a certain amount of that capability, “at least 4 CPU
 cores” for example. Further, a quantity of each amount required are allocated to a **Session** while that **Session**
-is running on a Worker Host. A Step requiring “at least 4 CPU cores” might result in a **Session** with 4 CPU cores 
-allocated to it being created on a Worker Host. Those cores are reserved for that **Session** while it is running on 
-the Worker Host. For scheduling purposes, this effectively reduces the number of available cores on the Worker Host by 
-4 for the duration of the **Session**. Logically fitting multiple **Sessions** into a single Worker Host is the key 
+is running on a Worker Host. A Step requiring “at least 4 CPU cores” might result in a **Session** with 4 CPU cores
+allocated to it being created on a Worker Host. Those cores are reserved for that **Session** while it is running on
+the Worker Host. For scheduling purposes, this effectively reduces the number of available cores on the Worker Host by
+4 for the duration of the **Session**. Logically fitting multiple **Sessions** into a single Worker Host is the key
 mechanism by which system resources can be optimized by a render management system.
 
-Attribute requirements are the mechanism for specifying an attribute a Worker Host must have for a Step to be scheduled 
+Attribute requirements are the mechanism for specifying an attribute a Worker Host must have for a Step to be scheduled
 to it. They are always defined on a Worker Host as a set of strings. A Step can assert that it requires a Worker Host to
-have specific value(s) of the attribute for it to be scheduled to the Worker Host. For example, a Step may require its 
-Tasks run on a host that is in the `"linux"` or `"macos"` family of operating systems, or that a host has the shared 
+have specific value(s) of the attribute for it to be scheduled to the Worker Host. For example, a Step may require its
+Tasks run on a host that is in the `"linux"` or `"macos"` family of operating systems, or that a host has the shared
 filesystems `"movie-A"`, `"shared-assets"`, and `"software"` all mounted.
 
 ## Stdout/Stderr Messages
 
-Open Job Description defines some special messages that can be emitted on stdout or stderr as a single line by an 
-**Action** when it is running within a **Session**. The application that is running the **Action** may intercept these 
+Open Job Description defines some special messages that can be emitted on stdout or stderr as a single line by an
+**Action** when it is running within a **Session**. The application that is running the **Action** may intercept these
 messages to convey information about the **Action** to the render management system. These special lines contain one of:
 
-* `openjd_progress: <number>` where `<number>` is a percentile between 0 and 100 that indicates what the progress of 
+* `openjd_progress: <number>` where `<number>` is a percentile between 0 and 100 that indicates what the progress of
   the **Action** is.
-* `openjd_status: <message>` where `<message>` is any string. This provides a human-readable status message indicating 
-  what the **Action** is doing. For example, a status message of `“loading assets”` or `"rendering"` or 
+* `openjd_status: <message>` where `<message>` is any string. This provides a human-readable status message indicating
+  what the **Action** is doing. For example, a status message of `“loading assets”` or `"rendering"` or
   `"dohickying the whatsits."`
-* `openjd_fail: <message>` where `<message>` is any string. This provides a human-readable message that indicates why 
+* `openjd_fail: <message>` where `<message>` is any string. This provides a human-readable message that indicates why
   an **Action** has failed.
 * `openjd_env: <var>=<value>` where `<var>` is the string name of an environment variable, and `<value>` is a string. This
   can only be emitted by the **Action** for entering an **Environment**. It defines the value of an environment variable for
@@ -90,7 +94,7 @@ An artists' workstation's filesystem may not match that of the Worker Host that 
 filesystems may be mounted in different locations, or the workstation and Worker Host may be different operating systems.
 Open Job Description provides mechanisms for running Tasks to discover and correct for these differences in environment.
 
-An application running an Open Job Description **Session** may communicate **Path Mapping Rules** to running subprocesses 
+An application running an Open Job Description **Session** may communicate **Path Mapping Rules** to running subprocesses
 via a JSON file in the **Session**'s **Working Directory**. This allows the render management system, which knows how and
 from what environment a Job was submitted, as well as the configuration of the Worker Host, to accurately control path
 mapping within the **Session**, by providing a set of programmatically generated **Path Mapping Rules**.
@@ -101,7 +105,7 @@ The format for the path mapping rules is:
 {
    "version": "pathmapping-1.0",
    # The path_mapping_rules list will be empty if there are no path mapping rules defined
-   "path_mapping_rules": [ 
+   "path_mapping_rules": [
       {
          # The path format that the submitting operating system uses
          "source_path_format": "POSIX" | "WINDOWS",
@@ -127,7 +131,7 @@ use in [Format Strings](How-Jobs-Are-Constructed#format-strings) within a Job Te
 
 ### Applying Path Mapping Rules within a Job Template
 
-The **PATH** type Job and Task parameters provide an integration point in the Job Template for the path mapping system. 
-If a collection of path mapping rules are provided to a **Session**, then those rules are applied to all **PATH** type 
-parameters when they are resolved in Format Strings. The path mapping rules that are supplied are applied in order of 
+The **PATH** type Job and Task parameters provide an integration point in the Job Template for the path mapping system.
+If a collection of path mapping rules are provided to a **Session**, then those rules are applied to all **PATH** type
+parameters when they are resolved in Format Strings. The path mapping rules that are supplied are applied in order of
 decreasing length of the source path, and processing stops for particular value once a rule matches.

--- a/wiki/Introduction-to-Creating-a-Job.md
+++ b/wiki/Introduction-to-Creating-a-Job.md
@@ -934,7 +934,7 @@ the Step's definition. You use this property to define the collection of inputs 
 In this case, you can create Tasks that either each render a single frame or each render a contiguous group of frames.
 Let's go over both.
 
-#### 2.2.4.1. One Frame per Task
+#### 2.2.4.1. Running One Frame at a Time
 
 The `render.sh` embedded script that you're using in the Job currently renders a sequence of frames rather than a single frame, so
 to render a single frame in each Task you'll first need to modify and test the `render.sh` embedded script.
@@ -974,7 +974,7 @@ blender --background "$SCENE" \
 rm -f $TMPFILE
 ```
 
-After copying that into the Job Template, create the Step's parameter space to define a single [`INT` type Task parameter](2023-09-Template-Schemas#3411-inttaskparameterdefinition) called `Frame` with a range of values from the `StartFrame` to the `EndFrame`:
+After copying that into the Job Template, create the Step's parameter space to define a single [`INT` type Task parameter](2023-09-Template-Schemas#3411-inttaskparameterdefinition) called `Frame` with a range of values from the `FrameStart` to the `FrameEnd`:
 
 ```yaml
 ...
@@ -1171,19 +1171,206 @@ steps:
 
 ```
 
-#### 2.2.4.2. Multiple Frames Per Task
+#### 2.2.4.2. Running Multiple Frames at a Time
 
 Some rendering applications may take a significant amount of time to startup and load the data that it needs to work. In this case,
-you may wish to render multiple contiguous frames of the animation in each Task. There are two ways that you can accomplish this
+you may wish to render multiple contiguous frames of the animation in each Task. There are several ways that you can accomplish this
 with Open Job Description:
 
-1. Define Task parameters for the start and end of the range of frames to render in each Task and leverage a
+1. If the implementation you're using supports the
+   [TASK_CHUNKING](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) extension,
+   enable that extension and then use the `CHUNK[INT]` type in place of `INT` for the `Frame` Task parameter.
+2. Define Task parameters for the start and end of the range of frames to render in each Task and leverage a
    [combination expression](2023-09-Template-Schemas#343-combinationexpr) to combine them; or
-2. Define Task parameter as a `STRING` type and hardcode the range of frames that we want to render in each Task.
+3. Define Task parameter as a `STRING` type and hardcode the range of frames that we want to render in each Task.
 
-We'll go through both options.
+We'll go through each of these options.
 
-##### 2.2.4.2.1. With a Combination Expression
+##### 2.2.4.2.1. With the TASK_CHUNKING extension
+
+This option is not implemented in the `openjd` command and libraries yet. This section will be updated when it is available.
+
+If the implementation you're using supports the
+[TASK_CHUNKING](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md) extension,
+you can enable it by adding the `extensions` list to your template so it starts like:
+
+```yaml
+specificationVersion: 'jobtemplate-2023-09'
+extensions:
+- TASK_CHUNKING
+```
+
+With this extension, you can structure your template to input a general range expression instead of using `FrameStart`
+and `FrameEnd` job parameters. You'll also want a `ChunkSize` parameter, so delete the `FrameStart` and `FrameEnd`
+definitions and add the following:
+
+```yaml
+  - name: Frames
+    type: STRING
+    default: "1-2"
+  - name: ChunkSize
+    type: INT
+    minValue: 1
+    default: 10
+```
+
+The benefit to using a `Frames` job parameter this way is that ranges like "1-100" and lists
+of pickup frames like "3,7,20-25,83" are both easy to support with the same syntax.
+
+Next, change the parameter space from type `INT` to `CHUNK[INT]` and wire the `ChunkSize` parameter in:
+
+```yaml
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: Frame
+          type: CHUNK[INT]
+          range: "{{Param.Frames}}"
+          chunks:
+            defaultTaskCount: "{{Param.ChunkSize}}"
+            rangeConstraint: CONTIGUOUS
+```
+
+Because we asked for contiguous chunks, the `{{Task.Param.Frame}}` value will always have a start and end value like `1-5`.
+If there's just one frame it will look like `1-1`. Because Blender uses a ".." instead of "-" to specify an interval
+of frames, the script needs to convert the syntax. Edit the script so the variable extraction and blender command
+look like this:
+
+```bash
+            SCENE="$1"
+            OUTDIR="$2"
+            FRAME_RANGE="$3"
+            FRAME_START="${FRAME_RANGE%%-*}"
+            FRAME_END="${FRAME_RANGE##*-}"
+
+            blender --background "$SCENE" \
+              --python "$TMPFILE" \
+              --render-output "$OUTDIR"/frame-### \
+              --render-format PNG --use-extension 1 \
+              --render-frame "${FRAME_START}..${FRAME_END}"
+```
+
+The complete template at this point looks like:
+
+```yaml
+specificationVersion: jobtemplate-2023-09
+extensions:
+- TASK_CHUNKING
+name: "{{Param.JobName}}"
+parameterDefinitions:
+  - name: SceneFile
+    type: PATH
+    dataFlow: IN
+    objectType: FILE
+  - name: FramesDirectory
+    type: PATH
+    dataFlow: OUT
+    objectType: DIRECTORY
+  - name: AnimationFile
+    type: PATH
+    dataFlow: OUT
+    objectType: FILE
+  - name: Frames
+    type: STRING
+    default: "1-2"
+  - name: ChunkSize
+    type: INT
+    minValue: 1
+    default: 10
+  - name: JobName
+    type: STRING
+    minLength: 1
+    default: "DemoJob"
+steps:
+  - name: BlenderRender
+    parameterSpace:
+      taskParameterDefinitions:
+        - name: Frame
+          type: CHUNK[INT]
+          range: "{{Param.Frames}}"
+          chunks:
+            defaultTaskCount: "{{Param.ChunkSize}}"
+            rangeConstraint: CONTIGUOUS
+    script:
+      actions:
+        onRun:
+          command: "{{Task.File.Render}}"
+          args:
+            - "{{Param.SceneFile}}"
+            - "{{Param.FramesDirectory}}"
+            - "{{Task.Param.Frame}}"
+          timeout: 60
+      embeddedFiles:
+        - name: Render
+          type: TEXT
+          filename: render.sh
+          runnable: true
+          data: |
+            #!/bin/bash
+
+            # Return an error code if any command in the script fails.
+            set -euo pipefail
+
+            # Use Blender's scripting interface to reduce the scene resolution and sampling rate to speed up testing.
+            # See https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Here-Documents
+            # Remove this and the lines below, `  --python "$TMPFILE" \` and `rm -f $TMPFILE`, after testing is complete.
+            TMPFILE=$(mktemp)
+            cat > "$TMPFILE" << EOF
+            import bpy
+            for s in bpy.data.scenes:
+              s.render.resolution_x = 480
+              s.render.resolution_y = 270
+            bpy.context.scene.cycles.samples = 100
+            EOF
+
+            SCENE="$1"
+            OUTDIR="$2"
+            FRAME_RANGE="$3"
+            FRAME_START="${FRAME_RANGE%%-*}"
+            FRAME_END="${FRAME_RANGE##*-}"
+
+            blender --background "$SCENE" \
+              --python "$TMPFILE" \
+              --render-output "$OUTDIR"/frame-### \
+              --render-format PNG --use-extension 1 \
+              --render-frame "${FRAME_START}..${FRAME_END}"
+
+            rm -f $TMPFILE
+
+  - name: EncodeVideo
+    dependencies:
+      - dependsOn: BlenderRender
+    script:
+      actions:
+        onRun:
+          command: "{{Task.File.Encode}}"
+          args:
+            - "{{Param.FramesDirectory}}"
+            - "{{Param.AnimationFile}}"
+            - "{{Param.FrameStart}}"
+          timeout: 60
+      embeddedFiles:
+        - name: Encode
+          type: TEXT
+          runnable: true
+          filename: encode.sh
+          data: |
+            #!/bin/bash
+
+            set -euo pipefail
+
+            INPUT_DIR="$1"
+            OUTPUT_FILENAME="$2"
+            START_FRAME="$3"
+
+            ffmpeg -y -r 10 -start_number "$START_FRAME" -i "$INPUT_DIR"/frame-%03d.png -pix_fmt yuv420p \
+                -vf "scale=in_color_matrix=bt709:out_color_matrix=bt709" \
+                -frames:v 300 -c:v libx264 -preset fast \
+                -color_range tv -colorspace bt709 -color_primaries bt709 -color_trc iec61966-2-1 \
+                -movflags faststart "$OUTPUT_FILENAME"
+
+```
+
+##### 2.2.4.2.2. With a Combination Expression
 
 The combination expression in a Step's parameter space gives you a way to choose how the Task parameters are combined to create
 the collection of Task values for the Step. For example, if you have a parameter space like:
@@ -1418,7 +1605,7 @@ steps:
                 -movflags faststart "$OUTPUT_FILENAME"
 ```
 
-##### 2.2.4.2.2 As STRING Type
+##### 2.2.4.2.3. As STRING Type
 
 This option is only suitable for cases where you will be writing or programmatically generating a Job Template for a specific input
 because the `FrameStart` and `FrameEnd` values need to be known when defining the set of values for the Task parameter. To create the


### PR DESCRIPTION
## PR to merge RFC 0001 into specification wiki

This PR merges the content from https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0001-task-chunking.md into the 2023-09 template schema wiki.

Content not specifically copied from the RFC:
* Added the `@extension EXTENSION_NAME` annotation to indicate which parts of the specification come from extensions.
* Added starting documentation about using the extension in the "Introduction to Creating a Job" wiki. This will be updated further once the extension is implemented in the CLI command and libraries.
* Updated the accepted dates of the two RFCs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
