### PR TITLE
fix: Fix publish_wiki GHA for " quotes in strings

### DIFF
--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -26,10 +26,13 @@ jobs:
           rsync -av --delete wiki/ tmp_wiki/ --exclude .git --exclude '*.drawio' --exclude README.md
           cd tmp_wiki
           git add .
-          git commit -m "${{ github.event.head_commit.message }}"
+          cat > .commit_message << EOF
+          ${{ github.event.head_commit.message }}
+          EOF
+          git commit -F .commit_message
           git push origin master
           rm -rf tmp_wiki
-          
-    
+
+
 
 


### PR DESCRIPTION
My last commit had a quote " character in the commit message, and that caused the wiki update to fail. This should hopefully fix it. I don't have a testing set up, so we'll test it in mainline.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
