### PR TITLE
fix: escape commit message

### DIFF
--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -14,6 +14,7 @@ jobs:
     environment: release
     env:
         WIKI_REPO: "https://${{ secrets.CI_TOKEN }}@github.com/OpenJobDescription/openjd-specifications.wiki.git"
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
     steps:
       - uses: actions/checkout@v4
       - name: "Clone wiki contents"
@@ -27,7 +28,7 @@ jobs:
           cd tmp_wiki
           git add .
           cat > .commit_message << EOF
-          ${{ github.event.head_commit.message }}
+          "${COMMIT_MESSAGE}"
           EOF
           git commit -F .commit_message
           git push origin master

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/.DS_Store
 .vscode
+.kiro


### PR DESCRIPTION
We weren't escaping the commit message properly. I followed the best practices here -> https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable

I tested this by by pushing to my fork, where I setup a wiki.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
