### PR TITLE
fix: realpath on macos doesn't work with non-existent paths

### DIFF
--- a/wiki/Job-Intro-02-Starting-With-Shell-Scripts.md
+++ b/wiki/Job-Intro-02-Starting-With-Shell-Scripts.md
@@ -155,8 +155,8 @@ Then modify it so that it accepts arguments from the command line:
 
 set -euo pipefail
 
-INPUT_DIR="$(realpath $1)"
-OUTPUT_FILENAME="$(realpath $2)"
+INPUT_DIR="$1"
+OUTPUT_FILENAME="$2"
 START_FRAME="$3"
 
 ffmpeg -y -r 10 -start_number "$START_FRAME" -i "$INPUT_DIR"/frame-%03d.png -pix_fmt yuv420p \


### PR DESCRIPTION
Fixes: #93 

The default `realpath` behaves differently between macOS and Linux. Paths must fully exist on macOS, but not Linux.

Remove `realpath` since it's not required for the script to work

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
