### PR TITLE
chore: Apply recent feedback bumping job param count to 200, add RFC 4 accepted date

### DIFF
--- a/rfcs/0004-enhanced-limits-and-capabilities.md
+++ b/rfcs/0004-enhanced-limits-and-capabilities.md
@@ -2,7 +2,7 @@
 * RFC Tracking Issue: <https://github.com/OpenJobDescription/openjd-specifications/issues/92>
 * Start Date: 2025-10-03
 * Specification Version: 2023-09 extension FEATURE_BUNDLE_1
-* Accepted On:
+* Accepted On: 2026-01-09
 
 ## Summary
 
@@ -146,11 +146,11 @@ steps:
   python:
     args: ["--additional-argument"]
     timeout: 5
-    cancelation: 
+    cancelation:
         mode: "NOTIFY_THEN_TERMINATE"
         notifyPeriodInSeconds: 30
     script: |
-      print('Hello from Python!') 
+      print('Hello from Python!')
 ```
 
 Compare to
@@ -164,7 +164,7 @@ steps:
         command: python
         args: ["{{Task.File.hello}}", "--additional-argument"]
         timeout: 5
-        cancelation: 
+        cancelation:
             mode: "NOTIFY_THEN_TERMINATE"
             notifyPeriodInSeconds: 30
     embeddedFiles:

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -59,7 +59,7 @@ Where:
    See: [&lt;JobParameterDefinition&gt;](#2-jobparameterdefinition).
       * Minimum number of elements: If provided, then this list must contain at least one element.
       * Maximum number of elements: The list must not contain more than 50
-      elements or 100 elements with the `FEATURE_BUNDLE_1` extension.
+      elements or 200 elements with the `FEATURE_BUNDLE_1` extension.
 7. *jobEnvironments* — An ordered list of the environments that are required to run Tasks in the Jobs created by this Job
    Template. These are entered in the order provided at the start of every Session for Tasks in the Job, and exited in the
    reverse order at the end of those Sessions. See: [&lt;Environment&gt;](#4-environment). Constraints:
@@ -1367,7 +1367,7 @@ expected to be available in the runtime environment.
         args: ["--additional-argument"] # optional
         script: |
           # bash code here
-  
+
   ### syntax sugar equivalent to:
 
   steps:
@@ -1478,7 +1478,7 @@ generated file. The file extension is `.py`. `python` (all lowercase) is
 expected to be available in the runtime environment.
 
   ```yaml
-  steps: 
+  steps:
     - name: PythonStep
       python:
         args: ["--additional-argument"] # optional
@@ -1486,7 +1486,7 @@ expected to be available in the runtime environment.
 
   ### syntax sugar equivalent to:
 
-  steps: 
+  steps:
     - name: PythonStep
       actions:
           onRun:


### PR DESCRIPTION
## PR for other purpose

Based on feedback, updating the max job param count from 100 to 200. Adding the RFC 0004 accepted date based on its PR merge.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
