### PR TITLE
chore: Add authors list to the RFC template

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,5 +1,6 @@
 
 * Feature Name: (fill in with a unique one or two word identifier. e.g. my_feature)
+* Author(s): (fill in all the authors as Author Name `[<github-user>](https://github.com/<github-user>)`)
 * RFC Tracking Issue: (fill in with the URL for the tracking issue in this repository)
 * Start Date: (fill in with today's date: YYYY-MM-DD)
 * Specification Version: 2023-09 extension (fill in with a chosen extension name as per RFC 0002)

--- a/rfcs/0001-task-chunking.md
+++ b/rfcs/0001-task-chunking.md
@@ -1,5 +1,6 @@
 
 * Feature Name: Task Chunking
+* Author(s): Mark Wiebe &lt;[mwiebe](https://github.com/mwiebe)&gt;
 * RFC Tracking Issue: https://github.com/OpenJobDescription/openjd-specifications/issues/53
 * Start Date: 2024-11-27
 * Specification Version: 2023-09 extension TASK_CHUNKING

--- a/rfcs/0002-model-extensions.md
+++ b/rfcs/0002-model-extensions.md
@@ -1,6 +1,7 @@
 
 * Feature Name: Model Extensions
-* RFC Tracking Issue: https://github.com/OpenJobDescription/openjd-specifications/issues/66
+* Author(s): Alex Hughes &lt;[Ahuge](https://github.com/Ahuge)&gt;
+* RFC Tracking Issue: https://github.com/OpenJobDescription/openjd-specifications/issues/57
 * Start Date: 2024-12-09
 * Accepted On: 2025-01-17
 

--- a/rfcs/0003-redacted-env-vars.md
+++ b/rfcs/0003-redacted-env-vars.md
@@ -1,4 +1,5 @@
 - Feature Name: Redacted Environment Variables
+- Author(s): baxeaz &lt;[baxeaz](https://github.com/baxeaz)&gt;
 - RFC Tracking Issue: https://github.com/OpenJobDescription/openjd-specifications/issues/85
 - Start Date: 2025-04-09
 - Specification Version: 2023-09 extension REDACTED_ENV_VARS

--- a/rfcs/0004-enhanced-limits-and-capabilities.md
+++ b/rfcs/0004-enhanced-limits-and-capabilities.md
@@ -1,4 +1,5 @@
 * Feature Name: Feature Bundle 1
+* Author(s): Cody Edwards &lt;[edwards-aws](https://github.com/edwards-aws)&gt;
 * RFC Tracking Issue: <https://github.com/OpenJobDescription/openjd-specifications/issues/92>
 * Start Date: 2025-10-03
 * Specification Version: 2023-09 extension FEATURE_BUNDLE_1


### PR DESCRIPTION
Our RFC template didn't have a field for Authors at the top. This adds the field, and populates the authors for the RFCs already accepted.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
