### PR TITLE
fix: handle trailing slashes in example test runner

### DIFF
--- a/conformance-tests/run_openjd_cli_tests.py
+++ b/conformance-tests/run_openjd_cli_tests.py
@@ -217,7 +217,7 @@ def main():
         sys.exit(0 if failed == 0 else 1)
     
     # Parse pattern: version/component/type/test_pattern
-    parts = args.pattern.split("/")
+    parts = args.pattern.strip("/").split("/")
     version_pat = parts[0] if len(parts) > 0 else "*"
     component_pat = parts[1] if len(parts) > 1 else "*"
     type_pat = parts[2] if len(parts) > 2 else "*"


### PR DESCRIPTION
With the example test runner, when a trailing slash was included in the test pattern argument (e.g., `2023-09/EXPR/`), the path split produced an empty string for the test type filter, causing `fnmatch` to match zero test directories and silently reporting 0 passed, 0 failed. This was confusing because the same pattern without the trailing slash worked correctly. Fixed by stripping trailing slashes from the pattern before splitting it into parts.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
