### PR TITLE
fix(expr): Rename re_replace to re_sub to match Python's re.sub

### DIFF
--- a/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-dollar-brace-group-ref.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-dollar-brace-group-ref.invalid.yaml
@@ -10,4 +10,4 @@ steps:
         command: python
         args:
         - -c
-        - "print(r\"{{ re_replace('hello', '(h)', r'\\1') }}\")"
+        - "print(r\"{{ re_sub('hello', '(h)', '${1}') }}\")"

--- a/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-dollar-group-ref.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-dollar-group-ref.invalid.yaml
@@ -10,4 +10,4 @@ steps:
         command: python
         args:
         - -c
-        - "print(r\"{{ re_replace('hello', '(h)', r'\\g<1>') }}\")"
+        - "print(r\"{{ re_sub('hello', '(h)', '$1') }}\")"

--- a/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-empty-pattern.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-empty-pattern.invalid.yaml
@@ -10,4 +10,4 @@ steps:
         command: python
         args:
         - -c
-        - "print(r\"{{ re_replace('hello', '', 'x') }}\")"
+        - "print(r\"{{ re_sub('hello', '', 'x') }}\")"

--- a/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-group-ref.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-group-ref.invalid.yaml
@@ -10,4 +10,4 @@ steps:
         command: python
         args:
         - -c
-        - "print(r\"{{ re_replace('hello', '(h)', '$1') }}\")"
+        - "print(r\"{{ re_sub('hello', '(h)', r'\\1') }}\")"

--- a/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-named-group-ref.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-sub-named-group-ref.invalid.yaml
@@ -10,4 +10,4 @@ steps:
         command: python
         args:
         - -c
-        - "print(r\"{{ re_replace('hello', '(h)', '${1}') }}\")"
+        - "print(r\"{{ re_sub('hello', '(h)', r'\\g<1>') }}\")"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-sub.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-sub.test.yaml
@@ -12,9 +12,9 @@ template:
           args:
           - -c
           - |
-            print(r'SINGLE:{{ re_replace("frame_001", r"\d+", "002") }}')
-            print(r'MULTI:{{ re_replace("a1b2c3", r"\d", "X") }}')
-            print(r'NO_MATCH:{{ re_replace("hello", r"\d+", "X") }}')
+            print(r'SINGLE:{{ re_sub("frame_001", r"\d+", "002") }}')
+            print(r'MULTI:{{ re_sub("a1b2c3", r"\d", "X") }}')
+            print(r'NO_MATCH:{{ re_sub("hello", r"\d+", "X") }}')
 expected:
   output:
   - SINGLE:frame_002

--- a/rfcs/0006-expression-function-library.md
+++ b/rfcs/0006-expression-function-library.md
@@ -515,7 +515,7 @@ the convention used by JavaScript and Ruby.
 | `re_match(s: string, pattern: string) -> list[string]?` | Match at START of string, return captured groups or null |
 | `re_search(s: string, pattern: string) -> list[string]?` | Match ANYWHERE in string, return captured groups or null |
 | `re_findall(s: string, pattern: string) -> list[string] \| list[list[string]]` | Find all non-overlapping matches; returns full matches if no groups, list of captured group values (not full matches) if one group, list of group lists if multiple groups |
-| `re_replace(s: string, pattern: string, repl: string) -> string` | Replace all regex matches with replacement. The `repl` string is literal text — group references (`\1`, `\g<1>`, `$1`, `${1}`) are not supported and are errors. |
+| `re_sub(s: string, pattern: string, repl: string) -> string` | Replace all regex matches with replacement. The `repl` string is literal text — group references (`\1`, `\g<1>`, `$1`, `${1}`) are not supported and are errors. |
 | `re_escape(s: string) -> string` | Escape regex metacharacters for literal matching |
 | `re_split(s: string, pattern: string) -> list[string]` | Split string by regex pattern |
 | `re_split(s: string, pattern: string, maxsplit: int) -> list[string]` | Split string by regex pattern, at most maxsplit times |
@@ -588,7 +588,7 @@ re_findall("shot010_shot020_shot035_comp.nk", r"shot\d+")    # returns ["shot010
 re_findall("v1.2.3 and v4.5.6", r"v(\d+)\.(\d+)\.(\d+)")     # returns [["1", "2", "3"], ["4", "5", "6"]]
 
 # Replace frame numbers
-re_replace("frame_001", r"\d+", "002")          # returns "frame_002"
+re_sub("frame_001", r"\d+", "002")          # returns "frame_002"
 
 # Escape user input for literal matching
 re_escape("file[1].txt")                        # returns "file\\[1\\]\\.txt"

--- a/wiki/2026-02-Expression-Language.md
+++ b/wiki/2026-02-Expression-Language.md
@@ -1491,7 +1491,7 @@ of a float literal.
 | `re_match(s: string, pattern: string) -> list[string]?` | Match at START of string, return captured groups or null |
 | `re_search(s: string, pattern: string) -> list[string]?` | Match ANYWHERE in string, return captured groups or null |
 | `re_findall(s: string, pattern: string) -> list[string] \| list[list[string]]` | Find all non-overlapping matches; returns full matches if no groups, list of captured group values (not full matches) if one group, list of group lists if multiple groups |
-| `re_replace(s: string, pattern: string, repl: string) -> string` | Replace all regex matches with replacement. The `repl` string is literal text — group references (`\1`, `\g<1>`, `$1`, `${1}`) are not supported and are errors. |
+| `re_sub(s: string, pattern: string, repl: string) -> string` | Replace all regex matches with replacement. The `repl` string is literal text — group references (`\1`, `\g<1>`, `$1`, `${1}`) are not supported and are errors. |
 | `re_escape(s: string) -> string` | Escape regex metacharacters for literal matching |
 | `re_split(s: string, pattern: string) -> list[string]` | Split string by regex pattern |
 | `re_split(s: string, pattern: string, maxsplit: int) -> list[string]` | Split string by regex pattern, at most maxsplit times |
@@ -1563,7 +1563,7 @@ re_findall("shot010_shot020_shot035_comp.nk", r"shot\d+")    # returns ["shot010
 re_findall("v1.2.3 and v4.5.6", r"v(\d+)\.(\d+)\.(\d+)")     # returns [["1", "2", "3"], ["4", "5", "6"]]
 
 # Replace frame numbers
-re_replace("frame_001", r"\d+", "002")          # returns "frame_002"
+re_sub("frame_001", r"\d+", "002")          # returns "frame_002"
 
 # Escape user input for literal matching
 re_escape("file[1].txt")                        # returns "file\\[1\\]\\.txt"


### PR DESCRIPTION
## Fix error in EXPR

Our intent in EXPR was to match Python's re functions generally, but we got re_replace instead of re_sub. This change renames that to line up with the Python standard library.

https://docs.python.org/3/library/re.html#re.sub

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
