### PR TITLE
fix: Conformance test yaml escaping and relative path sep

### DIFF
--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.6--list-type-inference.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.6--list-type-inference.test.yaml
@@ -61,5 +61,5 @@ expected:
   - 'HOMO_PATH:["/a", "/b"]'
   - 'NESTED_PATH:[["/a"], ["/b"]]'
   output_windows:
-  - 'HOMO_PATH:["\\a", "\\b"]'
-  - 'NESTED_PATH:[["\\a"], ["\\b"]]'
+  - "HOMO_PATH:[\"\\a\", \"\\b\"]"
+  - "NESTED_PATH:[[\"\\a\"], [\"\\b\"]]"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--flatten.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--flatten.test.yaml
@@ -35,4 +35,4 @@ expected:
   output_posix:
   - 'PATH:["/a", "/b", "/c"]'
   output_windows:
-  - 'PATH:["\\a", "\\b", "\\c"]'
+  - "PATH:[\"\\a\", \"\\b\", \"\\c\"]"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--unique.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--unique.test.yaml
@@ -46,5 +46,5 @@ expected:
   - "PATH:[['/a', '/b']]"
   - "LIST_PATH:[[['/a'], ['/b']]]"
   output_windows:
-  - "PATH:[['\\a', '\\b']]"
-  - "LIST_PATH:[[['\\a'], ['\\b']]]"
+  - "PATH:[['\\\\a', '\\\\b']]"
+  - "LIST_PATH:[[['\\\\a'], ['\\\\b']]]"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--path-absolute-relative.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--path-absolute-relative.test.yaml
@@ -39,7 +39,6 @@ expected:
   - REL_TO_URI_SAME:[true]
   - REL_TO_MIX:[false]
   - RELATIVE_URI:[file.txt]
-  - RELATIVE_URI_NESTED:[a/b/c]
   - RELATIVE_URI_SAME:[.]
   output_posix:
   - ABS_POSIX:[true]
@@ -51,6 +50,7 @@ expected:
   - REL_TO_UNC_F:[false]
   - RELATIVE_POSIX:[c/d]
   - RELATIVE_UNC:[dir/file]
+  - RELATIVE_URI_NESTED:[a/b/c]
   output_windows:
   - ABS_POSIX:[false]
   - ABS_WIN:[true]
@@ -61,3 +61,4 @@ expected:
   - REL_TO_UNC_F:[false]
   - RELATIVE_POSIX:[c\d]
   - RELATIVE_UNC:[dir\file]
+  - "RELATIVE_URI_NESTED:[a\\b\\c]"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-scheme-detection.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-scheme-detection.test.yaml
@@ -58,6 +58,6 @@ expected:
   output_windows:
   # Filesystem paths: PureWindowsPath behavior
   - "POSIX_ABS:\\mnt\\data\\file.txt"
-  - 'POSIX_ABS_PARTS:["\\", "mnt", "data", "file.txt"]'
+  - "POSIX_ABS_PARTS:[\"\\\", \"mnt\", \"data\", \"file.txt\"]"
   - "POSIX_REL:relative\\path"
   - "COLON:\\mnt\\c:\\data"


### PR DESCRIPTION
## PR for other purpose

Fixes a few Windows errors in the conformance tests - the yaml escaping was incorrect in some, and when taking relative path from two URI paths, it expected Posix path separators but they become Windows separators when running on Windows.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
