### PR TITLE
fix: Conformance test path value should expect \ separator on Windows

### DIFF
--- a/conformance-tests/2023-09/base/jobs/3.4--path-parameter.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4--path-parameter.test.yaml
@@ -18,8 +18,11 @@ template:
           - -c
           - print(r'TASK:InputFile={{Task.Param.InputFile}}')
 expected:
-  output:
+  output_posix:
   - TASK:InputFile=/path/a.exr
   - TASK:InputFile=/path/b.exr
+  output_windows:
+  - TASK:InputFile=\path\a.exr
+  - TASK:InputFile=\path\b.exr
   forbidden:
   - TASK:InputFile=/path/c.exr


### PR DESCRIPTION
## PR for other purpose

The 3.4--path-parameter.test.yaml conformance test expected Windows to preserve the `/` path separators. Path types should be normalized to the host format, however. The fix changes the expectation to `\`.

*Description of the change. What is being added or fixed?*

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
