### PR TITLE
test: Update checkbox test case to avoid YAML parsing ambiguity

### DIFF
--- a/conformance-tests/2023-09/base/job_templates/2.1--checkbox-case-insensitive.yaml
+++ b/conformance-tests/2023-09/base/job_templates/2.1--checkbox-case-insensitive.yaml
@@ -4,8 +4,8 @@ parameterDefinitions:
 - name: Enabled
   type: STRING
   allowedValues:
-  - TrUe
-  - FaLsE
+  - "TrUe"
+  - "FaLsE"
   userInterface:
     control: CHECK_BOX
 steps:


### PR DESCRIPTION
## PR for other purpose

In some Rust prototyping, we found that serde_yaml is no longer maintained, but saphyre parses booleans slightly differently. This conformance test was the only one affected, as it gets parsed as bools instead of as strings by saphyre.

This changes the test so we're not relying on specific parsers' interpretations of the YAML spec.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
