### PR TITLE
feat: Change repr_cmd to be more conservative

### DIFF
--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-cmd.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-cmd.test.yaml
@@ -15,9 +15,15 @@ template:
     - 'parens = repr_cmd("(foo)")'
     - 'pct = repr_cmd("100%")'
     - 'bang = repr_cmd("hello!")'
+    - 'bang_var = repr_cmd("!PATH!")'
+    - 'bang_caret = repr_cmd("a ^ b!")'
     - 'spaces = repr_cmd("hello world")'
     - |-
       newline = repr_cmd("a\nb")
+    - |-
+      newline_r = repr_cmd("a\rb")
+    - |-
+      newline_rn = repr_cmd("a\r\nb")
     - "list_val = repr_cmd([\"echo\", \"a & b\"])"
     script:
       actions:
@@ -36,8 +42,12 @@ template:
             print(r'PCT:{{ pct }}')
 
             print(r'BANG:{{ bang }}')
+            print(r'BANG_VAR:{{ bang_var }}')
+            print(r'BANG_CARET:{{ bang_caret }}')
             print(r'SPACES:{{ spaces }}')
-            print(r'NEWLINE_QUOTED:{{ newline == "\"a\nb\"" }}')
+            print(r'NEWLINE_STRIPPED:{{ newline }}')
+            print(r'NEWLINE_R_STRIPPED:{{ newline_r }}')
+            print(r'NEWLINE_RN_STRIPPED:{{ newline_rn }}')
             print(r'LIST:{{ list_val }}')
 expected:
   output:
@@ -49,7 +59,11 @@ expected:
   - "DQUOTE:\"say ^\"hi^\"\""
   - "PARENS:\"(foo)\""
   - "PCT:\"100%%\""
-  - "BANG:\"hello!\""
+  - "BANG:\"hello^^!\""
+  - "BANG_VAR:\"^^!PATH^^!\""
+  - "BANG_CARET:\"a ^^ b^^!\""
   - "SPACES:\"hello world\""
-  - "NEWLINE_QUOTED:true"
+  - "NEWLINE_STRIPPED:ab"
+  - "NEWLINE_R_STRIPPED:ab"
+  - "NEWLINE_RN_STRIPPED:ab"
   - "LIST:echo \"a & b\""

--- a/rfcs/0006-expression-function-library.md
+++ b/rfcs/0006-expression-function-library.md
@@ -631,13 +631,16 @@ Example: `repr_sh(["echo", "hello world"])` returns `"echo 'hello world'"`.
 `repr_cmd` produces Windows CMD-safe strings suitable for use in `.bat` files:
 
 - Strings containing special characters (`& | < > ^ " ( ) % !` or whitespace) are wrapped in double quotes.
-- Inside double quotes, `^` and `"` are escaped with a caret prefix, and `%` is doubled to `%%` (required for `.bat` file contexts). Other special characters are literal within quotes.
+- Inside double quotes, `^` and `"` are escaped with a caret prefix, `%` is doubled to `%%` (required for `.bat` file contexts), and `!` is escaped as `^^!` (required for contexts where `EnableDelayedExpansion` is active — the `^` must be doubled because `cmd.exe` processes `^` escapes before delayed expansion). Other special characters are literal within quotes.
+- Newline characters (`\n` and `\r`) are stripped from the string before quoting. A newline inside a double-quoted `cmd.exe` argument would cause `cmd.exe` to treat the content after the newline as a new command, which is a command injection vector. Because `cmd.exe` has no escape sequence for embedding a literal newline in an argument, stripping is the only safe option.
 - Simple strings without special characters are returned unquoted.
 - `repr_cmd("hello")` returns `hello`.
 - `repr_cmd("a & b")` returns `"a & b"` (`&` is literal inside quotes).
 - `repr_cmd("a ^ b")` returns `"a ^^ b"` (`^` escaped inside quotes).
 - `repr_cmd("100%")` returns `"100%%"` (`%` doubled for `.bat` files).
 - `repr_cmd('say "hi"')` returns `"say ^"hi^""`.
+- `repr_cmd("hello!")` returns `"hello^^!"` (`!` escaped for the delayed expansion context).
+- `repr_cmd("a\nb")` returns `"ab"` (newlines stripped).
 
 Example: `repr_cmd(["echo", "hello & world"])` returns `echo "hello & world"`.
 
@@ -650,6 +653,16 @@ concatenate the variable name with the path value inside `repr_cmd`:
 # Safe: OUTPUT_DIR is within the quotes and special characters in path are escaped
 set {{repr_cmd('OUTPUT_DIR=' + Param.OutputDirectory)}}
 ```
+
+**Limitations of `cmd.exe` quoting.** Unlike POSIX shells and PowerShell, `cmd.exe` does not
+support fully general string quoting. Modes such as `EnableDelayedExpansion` change how quoting
+and escaping are interpreted, and there is no single escaping strategy that is correct in all
+`cmd.exe` configurations simultaneously. `repr_cmd` escapes for default `cmd.exe` parsing rules
+as used in `.bat` files, and applies `^^!` escaping for `!` as a best-effort defense against
+delayed expansion. The transformations performed by `repr_cmd` do not preserve every input
+string in all `cmd.exe` modes. Template authors who need quoting guarantees beyond what
+`repr_cmd` provides should use a different script language such as PowerShell or Python, which
+have well-defined string escaping.
 
 `repr_pwsh` produces PowerShell literals with proper escaping:
 

--- a/wiki/2026-02-Expression-Language.md
+++ b/wiki/2026-02-Expression-Language.md
@@ -255,7 +255,7 @@ ExprValue(Decimal("3.140"))        # float (preserves decimal string)
 
 ```python
 ExprValue("42", type="int")        # coerce string to int
-ExprValue("3.14", type="float")    # coerce string to float  
+ExprValue("3.14", type="float")    # coerce string to float
 ExprValue("true", type="bool")     # coerce string to bool
 ExprValue("/tmp", type="path")     # string as path
 ExprValue("1-10", type="range_expr")  # string as range_expr
@@ -1605,16 +1605,25 @@ re_escape("file[1].txt")                        # returns "file\\[1\\]\\.txt"
 
 `repr_cmd` produces Windows CMD-safe strings suitable for use in `.bat` files.
 Strings containing special characters (`& | < > ^ " ( ) % !` or whitespace) are wrapped in
-double quotes. Inside double quotes, `^` and `"` are escaped with `^`, and `%` is doubled
+double quotes. Inside double quotes, `^` and `"` are escaped with `^`, `%` is doubled
 to `%%` (required for `.bat` file contexts where `%` triggers variable expansion even inside
-quotes). Other special characters are literal within quotes. Simple strings without special
+quotes), and `!` is escaped as `^^!` (required for contexts where `EnableDelayedExpansion` is
+active — the `^` must be doubled because `cmd.exe` processes `^` escapes before delayed
+expansion). Other special characters are literal within quotes. Newline characters (`\n` and
+`\r`) are stripped from the string before quoting, because `cmd.exe` has no escape sequence for
+embedding a literal newline in an argument and an unescaped newline inside double quotes would
+cause `cmd.exe` to treat the remainder as a new command. Simple strings without special
 characters are returned unquoted.
 
-Note: `repr_cmd` targets the default `cmd.exe` parsing rules without `EnableDelayedExpansion`.
-The `!` character is not escaped; if the output is used in a `.bat` file that enables delayed
-expansion (`SETLOCAL ENABLEDELAYEDEXPANSION`), `!` will be interpreted as a variable expansion
-trigger and there is no single escaping that works in both modes. Template authors should avoid
-delayed expansion in scripts that use `repr_cmd` output.
+**Limitations of `cmd.exe` quoting.** Unlike POSIX shells and PowerShell, `cmd.exe` does not
+support fully general string quoting. Modes such as `EnableDelayedExpansion` change how quoting
+and escaping are interpreted, and there is no single escaping strategy that is correct in all
+`cmd.exe` configurations simultaneously. `repr_cmd` escapes for default `cmd.exe` parsing rules
+as used in `.bat` files, and applies `^^!` escaping for `!` as a best-effort defense against
+delayed expansion. The transformations performed by `repr_cmd` do not preserve every input
+string in all `cmd.exe` modes. Template authors who need quoting guarantees beyond what
+`repr_cmd` provides should use a different script language such as PowerShell or Python, which
+have well-defined string escaping.
 
 `repr_pwsh` produces PowerShell literals with proper escaping. Strings and paths are wrapped in
 single quotes with embedded single quotes doubled. Booleans become `$true`/`$false`. Lists become
@@ -1627,6 +1636,8 @@ Examples:
 - `repr_sh(["echo", "hello world"])` returns `"echo 'hello world'"`
 - `repr_cmd("a & b")` returns `"\"a & b\""` (quoted, `&` is literal inside quotes)
 - `repr_cmd("a ^ b")` returns `"\"a ^^ b\""` (`^` escaped inside quotes)
+- `repr_cmd("hello!")` returns `"\"hello^^!\""` (`!` escaped as `^^!` for the delayed expansion context)
+- `repr_cmd("a\nb")` returns `"\"ab\""` (newlines stripped)
 - `repr_pwsh(["a", "b"])` returns `@('a', 'b')`
 - `repr_py("hello\nworld")` returns `"'hello\\nworld'"`
 - `repr_json([1, 2, 3])` returns `"[1, 2, 3]"`


### PR DESCRIPTION
## PR for other purpose

The initially selected approach for `repr_cmd` focused on working best in a default .bat file context. With further analysis we concluded this is not a good idea, and are adjusting it to escape strings more thoroughly with the tradeoff that values such as `!` won't be preserved.

In the EXPR specification and corresponding wiki/ spec document, change the repr_cmd function to escape `!` for the delayed expansion context, and to remove newlines. The cmd interpreter syntax doesn't support fully general string escaping, and this strikes a better balance between functionality and safety.

Users needing more functionality should use a different scripting language like PowerShell or Python.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
