### PR TITLE
feat: Add openjd-rs Rust implementation to project documentation and CI

### DIFF
--- a/.github/workflows/conformance_tests_rust.yml
+++ b/.github/workflows/conformance_tests_rust.yml
@@ -1,0 +1,49 @@
+name: Conformance Tests (Rust)
+
+on:
+  push:
+    branches: [ mainline ]
+    paths:
+      - conformance-tests/**
+  pull_request:
+    branches: [ mainline ]
+    paths:
+      - conformance-tests/**
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install Rust stable
+      shell: bash
+      run: |
+        rustup toolchain install stable --profile minimal
+        rustup override set stable
+
+    - name: Install openjd CLI
+      shell: bash
+      run: cargo install openjd-cli
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+
+    - name: Run conformance tests (Unix)
+      if: runner.os != 'Windows'
+      working-directory: conformance-tests
+      run: uv run run_openjd_cli_tests.py
+
+    - name: Run conformance tests (Windows)
+      if: runner.os == 'Windows'
+      working-directory: conformance-tests
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+        uv run run_openjd_cli_tests.py

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ submit a pull request.*
 
 * [openjd-cli](https://github.com/OpenJobDescription/openjd-cli) - A command-line
   interface for running and working with Open Job Description templates.
+* [openjd-rs CLI](https://github.com/OpenJobDescription/openjd-rs) - A Rust
+  implementation providing a high-performance command-line interface for validating,
+  summarizing, and running Open Job Description templates.
 
 ### Libraries
 
@@ -59,6 +62,9 @@ submit a pull request.*
 * [openjd-adaptor-runtime](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python) - A Python library
   for creating a command-line Adaptor to assist with integrating an existing application, such as a rendering
   application, into batch computing systems that run Jobs in a way that is compatible with Open Job Description Sessions.
+* [openjd-rs](https://github.com/OpenJobDescription/openjd-rs) - A Rust workspace
+  providing crates for the expression language (`openjd-expr`), data model
+  (`openjd-model`), and session runtime (`openjd-sessions`) for Open Job Description.
 
 ## Contributing
 

--- a/conformance-tests/2023-09/base/job_templates/1.1--unknown-extra-field.invalid.json
+++ b/conformance-tests/2023-09/base/job_templates/1.1--unknown-extra-field.invalid.json
@@ -1,0 +1,18 @@
+{
+  "specificationVersion": "jobtemplate-2023-09",
+  "name": "TestJob",
+  "unknownField": "some value",
+  "steps": [
+    {
+      "name": "Step1",
+      "script": {
+        "actions": {
+          "onRun": {
+            "command": "python",
+            "args": ["-c", "print()"]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -49,6 +49,16 @@ briefly provide the rationale you used for the choice.
 Discuss prior art, both the good and the bad, in relation to the proposal. Does a feature
 like this exist in other systems? How is it expressed in those system(s)?
 
+## Implementation Impact
+
+Describe the expected implementation complexity for known OpenJD implementations:
+
+- **Python (openjd-model)**: [impact description]
+- **Rust (openjd-rs)**: [impact description]
+
+Are there features of this RFC that may be significantly harder to implement in one language
+vs another? Are there performance implications?
+
 ## Rejected Ideas
 
 Why certain ideas that were brought while discussing this RFC were not ultimately pursued.

--- a/wiki/Job-Intro-01-Toolchain-Setup.md
+++ b/wiki/Job-Intro-01-Toolchain-Setup.md
@@ -1,14 +1,33 @@
 # Toolchain Setup
 
-To replicate the steps taken in this guide you will need to have the [Open Job Description CLI](https://pypi.org/project/openjd-cli/),
-[Python](https://www.python.org/), [Blender](https://www.blender.org/), and [FFmpeg](https://www.ffmpeg.org/) installed.
+To replicate the steps taken in this guide you will need to have the Open Job Description CLI,
+[Blender](https://www.blender.org/), and [FFmpeg](https://www.ffmpeg.org/) installed.
 Open Job Description's CLI provides easy to use subcommands for validating the syntax of a Job Template,
-running Tasks defined by a Job Template locally on your workstation, and more. The CLI is written in Python, so you will need to have
-Python 3.9 or higher available on your workstation; for information on how to install Python, please see the official
-[Python.org website](https://www.python.org/).
+running Tasks defined by a Job Template locally on your workstation, and more. There are two CLI implementations
+available — choose whichever fits your environment:
+
+## Option A: Python CLI
+
+The [Python CLI](https://pypi.org/project/openjd-cli/) requires Python 3.9 or higher; for information on how to
+install Python, please see the official [Python.org website](https://www.python.org/).
 
 We suggest installing the tooling into a Python virtual environment based on [venv](https://docs.python.org/3/library/venv.html)
 or [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#term-Miniforge).
+
+```bash
+pip install openjd-cli
+```
+
+## Option B: Rust CLI
+
+The [Rust CLI](https://crates.io/crates/openjd-cli) is a standalone binary.
+Install it with [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html):
+
+```bash
+cargo install openjd-cli
+```
+
+Both CLIs provide the same `check`, `summary`, and `run` subcommands used throughout this guide.
 
 For writing Job Templates by hand we also recommend using [Visual Studio Code](https://code.visualstudio.com/)
 and configuring it so that it can auto-complete the syntax of your Job Templates. To configure auto-complete, you


### PR DESCRIPTION
Add the Rust CLI and library crates to the README project listings, update the toolchain setup guide with Rust installation instructions, add an Implementation Impact section to the RFC template, and add a CI workflow to run conformance tests against the Rust CLI.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
