### PR TITLE
test(expr): Add conformance tests for target_type handling

### DIFF
--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.3--union-target-no-match.invalid.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.3--union-target-no-match.invalid.test.yaml
@@ -1,0 +1,28 @@
+---
+# Per Expression Language §1.2.3, when a value cannot satisfy any member
+# of a union target type via match-first or non-destructive coercion,
+# evaluation must produce an error. Here a list[string] is provided where
+# the INT range field expects `int | string | range_expr | list[int]` —
+# list[string] is not a member, and cannot be coerced to list[int] because
+# the string elements are not numeric.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Names
+    type: LIST[STRING]
+    default: ["alice", "bob"]
+  steps:
+  - name: Step1
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: V
+        type: INT
+        range: "{{ Param.Names }}"
+    script:
+      actions:
+        onRun:
+          command: python
+          args: ["-c", "print(r'{{Task.Param.V}}')"]

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.3--union-target-type.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.3--union-target-type.test.yaml
@@ -1,0 +1,149 @@
+---
+# Per Expression Language §1.2.3 (Implicit Type Coercion), when the
+# target type is a union, a value whose type already matches one of the
+# union's members satisfies the target trivially (match-first). Otherwise
+# non-destructive coercion is attempted to each scalar member
+# (coerce-to-member). A buggy evaluator may reject every union target via
+# its strict-equality early return because the value's type doesn't equal
+# the union as a whole — exercising both paths here ensures all branches
+# are reachable.
+#
+# Targets exercised:
+#   - INT task `range`:  int | string | range_expr | list[int]  (match-first)
+#   - args item slot:    string? | list[string]  (coerce int→string, bool→string)
+#   - args item slot:    string? | list[string]  (null→skip via nulltype member)
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: UnionTargetType
+  parameterDefinitions:
+  - name: StrFrames
+    type: STRING
+    default: "1-3"
+  - name: IntCount
+    type: INT
+    default: 7
+  - name: RangeFrames
+    type: RANGE_EXPR
+    default: "10-11"
+  steps:
+  # 1. STRING value satisfies the `int | string | range_expr | list[int]`
+  #    union via match-first (string is a member).
+  - name: StringMember
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: V
+        type: INT
+        range: "{{ Param.StrFrames }}"
+    script:
+      actions:
+        onRun:
+          command: python
+          args: ["-c", "print(r'STRING:{{Task.Param.V}}')"]
+  # 2. INT value satisfies the same union via match-first (int is a member).
+  - name: IntMember
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: V
+        type: INT
+        range: "{{ Param.IntCount }}"
+    script:
+      actions:
+        onRun:
+          command: python
+          args: ["-c", "print(r'INT:{{Task.Param.V}}')"]
+  # 3. RANGE_EXPR value satisfies the union (range_expr is a member).
+  - name: RangeMember
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: V
+        type: INT
+        range: "{{ Param.RangeFrames }}"
+    script:
+      actions:
+        onRun:
+          command: python
+          args: ["-c", "print(r'RANGE:{{Task.Param.V}}')"]
+  # 4. LIST[INT] value satisfies the union (list[int] is a member).
+  - name: ListMember
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: V
+        type: INT
+        range: "{{ [100, 101] }}"
+    script:
+      actions:
+        onRun:
+          command: python
+          args: ["-c", "print(r'LIST:{{Task.Param.V}}')"]
+  # 5. Arithmetic into the union: BinOp evaluates with unconstrained
+  #    target type (per propagation rules), and the resulting INT
+  #    satisfies the int member of the range union.
+  - name: ArithIntoRange
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: V
+        type: INT
+        range: "{{ Param.IntCount + 1 }}"
+    script:
+      actions:
+        onRun:
+          command: python
+          args: ["-c", "print(r'ARITH:{{Task.Param.V}}')"]
+  # 6. Coerce-to-member via args slot: the target for a bare expression
+  #    in an args item is `string? | list[string]`. An INT value does not
+  #    match any member directly, so coerce-to-member fires: int→string
+  #    is non-destructive per §1.2.3. A buggy evaluator that only checks
+  #    strict type equality against the union will reject this.
+  - name: CoerceIntInArgs
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            import sys
+            for i, a in enumerate(sys.argv[1:]):
+                print(f'COERCE_A{i}:{a}')
+          - "{{ Param.IntCount }}"
+          - "{{ Param.IntCount + 3 }}"
+          - "{{ true }}"
+  # 7. Optional target: a null value satisfies `T | nulltype` (the union
+  #    representation of an optional type T?). For an args list item with
+  #    target `T? | list[T]`, a null result causes the item to be skipped.
+  - name: OptionalSkip
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            import sys
+            for i, a in enumerate(sys.argv[1:]):
+                print(f'OPT_A{i}:{a}')
+            print(f'OPT_COUNT:{len(sys.argv) - 1}')
+          - "first"
+          - "{{ null if true else 'should-not-appear' }}"
+          - "last"
+expected:
+  output:
+  - "STRING:1"
+  - "STRING:2"
+  - "STRING:3"
+  - "INT:7"
+  - "RANGE:10"
+  - "RANGE:11"
+  - "LIST:100"
+  - "LIST:101"
+  - "ARITH:8"
+  - "COERCE_A0:7"
+  - "COERCE_A1:10"
+  - "COERCE_A2:true"
+  - "OPT_A0:first"
+  - "OPT_A1:last"
+  - "OPT_COUNT:2"
+  forbidden:
+  - "should-not-appear"

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-type-propagation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-type-propagation.test.yaml
@@ -1,0 +1,61 @@
+---
+# Per Expression Language §1.3.1 (Target Type Evaluation) and §1.3.2
+# (Evaluation Within Template Schemas), operands of BinOp, UnaryOp,
+# Compare, and the test slot of IfExp are evaluated WITHOUT inheriting
+# the parent's target type. Embedding these expressions in a format
+# string with surrounding text places them in an unconstrained context
+# (§1.3.2: "Each interpolated expression is evaluated without type
+# constraints to obtain its natural result, then converted to a
+# string."). If a buggy evaluator coerces operands to strings before
+# the operator runs, the arithmetic and comparison cases below will
+# fail with a type error instead of producing the expected output.
+#
+# Note: BINOP_DIV asserts `10 / 4 = 2.5` — per §2.1.1 __truediv__
+# always returns float even for int operands.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TargetTypePropagation
+  parameterDefinitions:
+  - name: Count
+    type: INT
+    default: 10
+  - name: Threshold
+    type: INT
+    default: 5
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            # BinOp operands must keep their numeric types
+            print(r'BINOP_SUB:{{ Param.Count - 1 }}')
+            print(r'BINOP_MUL:{{ Param.Count * 2 }}')
+            print(r'BINOP_DIV:{{ Param.Count / 4 }}')
+            # UnaryOp operand must keep its numeric type
+            print(r'UNARY_NEG:{{ -Param.Count }}')
+            print(r'UNARY_NOT:{{ not (Param.Count > Param.Threshold) }}')
+            # Compare operands must keep their numeric types
+            print(r'CMP_GT:{{ Param.Count > Param.Threshold }}')
+            print(r'CMP_LE:{{ Param.Count - 5 <= Param.Threshold }}')
+            # IfExp.test slot must be evaluated unconstrained, body/orelse
+            # inherit the outer string target
+            print(r'IFEXP:{{ "big" if Param.Count > Param.Threshold else "small" }}')
+            # Compound: arithmetic feeding a comparison feeding a ternary
+            print(r'CHAIN:{{ "over" if Param.Count - Param.Threshold > 3 else "under" }}')
+expected:
+  output:
+  - "BINOP_SUB:9"
+  - "BINOP_MUL:20"
+  - "BINOP_DIV:2.5"
+  - "UNARY_NEG:-10"
+  - "UNARY_NOT:false"
+  - "CMP_GT:true"
+  - "CMP_LE:true"
+  - "IFEXP:big"
+  - "CHAIN:over"

--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -50,6 +50,7 @@ Filenames encode the spec section they test:
 
 - `<spec-section>` - Reference to the [Template Schema](../wiki/2023-09-Template-Schemas.md) section (e.g., `1.1`, `3.3.2`, `7.3`)
 - `.invalid` - Test should FAIL validation/execution
+- `.invalid.test` - Job execution test that should FAIL at runtime (in `jobs/` directory). Use this when the template passes static validation but the error only fires during evaluation.
 - `.test` - Job execution test (in `jobs/` directory)
 
 For the `EXPR` extension, tests may reference either the Template Schema or the


### PR DESCRIPTION
Cover the EXPR target_type cases from [openjd-rs#192](https://github.com/OpenJobDescription/openjd-rs/pull/192) and [openjd-rs#193](https://github.com/OpenJobDescription/openjd-rs/pull/193), addressing #141.

### What's added

Three new tests under `conformance-tests/2023-09/EXPR/jobs/`:

- **`expr1.3.1--target-type-propagation.test.yaml`** — Covers [openjd-rs#192](https://github.com/OpenJobDescription/openjd-rs/pull/192). Asserts that operands of `BinOp`, `UnaryOp`, `Compare`, and the `test` slot of `IfExp` are evaluated **without** inheriting the parent's target type, per [Expression Language §1.3.1](../wiki/2026-02-Expression-Language.md#131-target-type-evaluation) and [§1.3.2](../wiki/2026-02-Expression-Language.md#132-evaluation-within-template-schemas). Each case is embedded in a string-target format string so a buggy evaluator that pushes the string target into operands would fail with type errors (e.g. `Cannot use '-' operator with string and string`).

- **`expr1.2.3--union-target-type.test.yaml`** — Covers [openjd-rs#193](https://github.com/OpenJobDescription/openjd-rs/pull/193). Exercises union target satisfaction along the paths called out in [§1.2.3 (Implicit Type Coercion)](../wiki/2026-02-Expression-Language.md#123-implicit-type-coercion):
  - **INT task `range:` field** ([§1.3.12](../wiki/2026-02-Expression-Language.md#1312-task-parameter-range-field-extensions)): an expression evaluating to `string`, `int`, `range_expr`, or `list[int]` reaches the slot — four steps, one per shape.
  - **Args item slot** ([§1.3.2](../wiki/2026-02-Expression-Language.md#132-evaluation-within-template-schemas)): target `string? | list[string]`. `int` and `bool` reach the slot via coerce-to-member (`int → string`, `bool → string`); `null` matches the `nulltype` member and skips the arg entirely.
  - One step composes both PRs by feeding `Param.IntCount + 1` into the range slot — arithmetic operands run unconstrained per [openjd-rs#192](https://github.com/OpenJobDescription/openjd-rs/pull/192), and the resulting `int` reaches the slot.

- **`expr1.2.3--union-target-no-match.invalid.test.yaml`** — Error path: a `list[string]` of non-numeric values fed into the INT range slot. Neither match-first nor non-destructive coercion (`list[string] → list[int]` would require `int("alice")`) succeeds, so the evaluator must error per [§1.2.3](../wiki/2026-02-Expression-Language.md#123-implicit-type-coercion). Lives under `jobs/` rather than `job_templates/` because the rejection only fires at evaluation time — `openjd check` accepts the template since the type system can't see the per-element coercion failure until values are bound.

### Documentation

Adds the `.invalid.test` filename suffix to `conformance-tests/README.md`, since this PR introduces the first test in the suite that uses it.

### Validation

- `Conformance Tests Rust` workflow: **passes** on Ubuntu, macOS, and Windows. This is the workflow that exercises the suite against an `openjd-rs` build containing the [openjd-rs#192](https://github.com/OpenJobDescription/openjd-rs/pull/192) and [openjd-rs#193](https://github.com/OpenJobDescription/openjd-rs/pull/193) fixes.

Failed tests in CI - known mainline failure
- `Conformance Tests` workflow (Python `openjd-cli`): **expected red** — `openjd-cli` 0.7.5 does not yet implement the `EXPR` extension and rejects every EXPR test in the suite (`Unsupported extension names: EXPR`). This failure is pre-existing on `mainline` for the last 10+ runs, and the workflow's own comment acknowledges it: *"We expect some tests to fail with the openjd CLI at the moment. The CLI is also not in the scope of this repo, so PRs in this repo should not depend too specifically on its functionality."*

Local run against `openjd-rs`:

```
2023-09/EXPR/jobs:
  ✓ expr1.2.3--union-target-no-match
  ✓ expr1.2.3--union-target-type
  ✓ expr1.3.1--target-type-propagation
  3 passed, 0 failed
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
