### PR TITLE
feat: EXPR runtime value-constraint and format-string coercion conformance tests

### DIFF
--- a/conformance-tests/2023-09/EXPR/jobs/2.10--range-expr-supplied-value-invalid.invalid.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.10--range-expr-supplied-value-invalid.invalid.test.yaml
@@ -1,0 +1,27 @@
+# A user-SUPPLIED RANGE_EXPR value must be validated against the integer
+# range-expression grammar at job creation time, not only the template default.
+# "1-abc" is not a valid range expression, so job creation must fail.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Frames
+    type: RANGE_EXPR
+  steps:
+  - name: Step1
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: Frame
+        type: INT
+        range: "{{Param.Frames}}"
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print()
+parameters:
+  Frames: "1-abc"

--- a/conformance-tests/2023-09/EXPR/jobs/2.11--list-string-supplied-value-item-not-in-allowed.invalid.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.11--list-string-supplied-value-item-not-in-allowed.invalid.test.yaml
@@ -1,0 +1,24 @@
+# A user-SUPPLIED LIST[STRING] value must be validated against the parameter's
+# item.allowedValues constraint at job creation time. The supplied value
+# contains "z", which is not in the allowed set, so job creation must fail.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Tags
+    type: LIST[STRING]
+    item:
+      allowedValues: ["a", "b"]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print()
+parameters:
+  Tags: ["a", "z"]

--- a/conformance-tests/2023-09/EXPR/jobs/2.11--list-string-supplied-value-too-long.invalid.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.11--list-string-supplied-value-too-long.invalid.test.yaml
@@ -1,0 +1,23 @@
+# A user-SUPPLIED LIST[STRING] value must be validated against the parameter's
+# list-length (maxLength) constraint at job creation time. Here maxLength is 2
+# and the supplied value has 3 items, so job creation must fail.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Tags
+    type: LIST[STRING]
+    maxLength: 2
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print()
+parameters:
+  Tags: ["a", "b", "c"]

--- a/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-merged-default-compatible.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-merged-default-compatible.test.yaml
@@ -1,0 +1,46 @@
+# When the same EXPR LIST[INT] job parameter is defined in both an environment
+# template and the job template, a merged (last-defined) default that satisfies
+# the surviving definition's constraints must be accepted and used as the
+# parameter's value. Companion to the merged-default .invalid test, ensuring the
+# merge re-validation does not over-reject a compatible default.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Values
+    type: LIST[INT]
+    maxLength: 5
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            print(r'LEN:{{ len(Param.Values) }}')
+            print(r'SUM:{{ sum(Param.Values) }}')
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - EXPR
+  parameterDefinitions:
+  - name: Values
+    type: LIST[INT]
+    default: [1, 2, 3]
+  environment:
+    name: Env1
+    script:
+      actions:
+        onEnter:
+          command: python
+          args:
+          - -c
+          - print()
+expected:
+  output:
+  - LEN:3
+  - SUM:6

--- a/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-merged-default-violates-constraint.invalid.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-merged-default-violates-constraint.invalid.test.yaml
@@ -1,0 +1,43 @@
+# When the same EXPR LIST[INT] job parameter is defined in both an environment
+# template and the job template, the merged (last-defined) default must be
+# re-validated against the surviving definition's constraints. Here the
+# environment template supplies default [1,2,3,4,5] while the job template
+# constrains the parameter to maxLength 2 (and supplies no default). The
+# carried-over default violates maxLength, so creating the job must fail.
+# Mirrors the openjd-rs reference, which merges the default forward and then
+# value-checks it.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Values
+    type: LIST[INT]
+    maxLength: 2
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print()
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - EXPR
+  parameterDefinitions:
+  - name: Values
+    type: LIST[INT]
+    default: [1, 2, 3, 4, 5]
+  environment:
+    name: Env1
+    script:
+      actions:
+        onEnter:
+          command: python
+          args:
+          - -c
+          - print()

--- a/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-supplied-value-item-above-max.invalid.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-supplied-value-item-above-max.invalid.test.yaml
@@ -1,0 +1,26 @@
+# A user-SUPPLIED LIST[INT] value (not just the template default) must be
+# validated against the parameter's item constraints when the job is created.
+# Here item.maxValue is 10 and the supplied value contains 999, so job creation
+# must fail. Mirrors the openjd-rs reference, which enforces list item
+# constraints on supplied values via JobParameterDefinition::check_value_constraints.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Values
+    type: LIST[INT]
+    item:
+      maxValue: 10
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print()
+parameters:
+  Values: [1, 2, 999]

--- a/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-supplied-value-within-constraints.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-supplied-value-within-constraints.test.yaml
@@ -1,0 +1,32 @@
+# A user-SUPPLIED LIST[INT] value that satisfies the parameter's constraints
+# (item.maxValue and maxLength) must be accepted and usable in expressions.
+# Companion to the .invalid runtime constraint tests, ensuring the value-level
+# check does not over-reject valid values.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Values
+    type: LIST[INT]
+    maxLength: 5
+    item:
+      maxValue: 10
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            print(r'LEN:{{ len(Param.Values) }}')
+            print(r'SUM:{{ sum(Param.Values) }}')
+parameters:
+  Values: [3, 5, 7]
+expected:
+  output:
+  - LEN:3
+  - SUM:15

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--scalar-string-coercion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--scalar-string-coercion.test.yaml
@@ -1,0 +1,47 @@
+# Expression Language §1.3.2: format-string string coercion of EXPR scalar
+# results embedded in surrounding text.
+#
+# A boolean coerces to lowercase "true"/"false" (NOT Python-style "True"/
+# "False"), a null result coerces to the empty string, and a float preserves
+# its source spelling (e.g. trailing zeros). This guards against an
+# implementation stringifying the native value with a language-native repr.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Enabled
+    type: BOOL
+    default: true
+  - name: Disabled
+    type: BOOL
+    default: false
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            print(r'BOOL_PARAM:{{ Param.Enabled }}')
+            print(r'BOOL_FALSE:{{ Param.Disabled }}')
+            print(r'BOOL_LITERAL:{{ true }}')
+            print(r'NEGATION:{{ not Param.Enabled }}')
+            print(r'NULL:[{{ null }}]')
+            print(r'FLOAT:{{ 1.50 }}')
+expected:
+  output:
+  - "BOOL_PARAM:true"
+  - "BOOL_FALSE:false"
+  - "BOOL_LITERAL:true"
+  - "NEGATION:false"
+  - "NULL:[]"
+  - "FLOAT:1.50"
+  forbidden:
+  - "BOOL_PARAM:True"
+  - "BOOL_FALSE:False"
+  - "NULL:[None]"
+  - "NULL:[null]"


### PR DESCRIPTION
## Summary

Adds EXPR extension conformance tests covering two gaps in the `2023-09` spec:

1. **Runtime value-constraint validation** — user-supplied parameter values (not just template defaults) must be validated against their type grammar and declared constraints at job creation time.
2. **Format-string coercion** — EXPR scalar results embedded in surrounding text must coerce to their canonical string form, independent of the host language's native `repr`.

All tests target `conformance-tests/2023-09/EXPR/jobs/`.

## Value-constraint conformance

Verifies that supplied values are re-validated, and that valid values are accepted (no over-rejection):

| Test | Type | Expectation |
|------|------|-------------|
| `2.10--range-expr-supplied-value-invalid` | `RANGE_EXPR` | Supplied `"1-abc"` fails the range-expression grammar → job creation rejected |
| `2.11--list-string-supplied-value-item-not-in-allowed` | `LIST[STRING]` | Item outside `item.allowedValues` → rejected |
| `2.11--list-string-supplied-value-too-long` | `LIST[STRING]` | List exceeds length constraint → rejected |
| `2.13--list-int-supplied-value-item-above-max` | `LIST[INT]` | Item above `item.max` → rejected |
| `2.13--list-int-supplied-value-within-constraints` | `LIST[INT]` | Valid value accepted |
| `2.13--list-int-merged-default-compatible` | `LIST[INT]` | Merged (last-defined) default from env + job template satisfies surviving constraints → accepted |
| `2.13--list-int-merged-default-violates-constraint` | `LIST[INT]` | Merged default violates surviving constraints → rejected |

The two `merged-default` cases are companions: one confirms rejection of an incompatible merged default, the other guards against over-rejecting a compatible one.

## Format-string coercion conformance

`expr1.3.2--scalar-string-coercion` (Expression Language §1.3.2) asserts canonical coercion of scalar results embedded in text:

- `BOOL` → lowercase `true` / `false` (not `True` / `False`)
- `null` → empty string (not `None` or `null`)
- `FLOAT` → preserves source spelling, e.g. `1.50` keeps its trailing zero

Uses a `forbidden` output block to explicitly reject language-native stringifications.

## Testing

Conformance test additions only — no changes to spec text or tooling. Each `.invalid.test.yaml` asserts job-creation failure; each `.test.yaml` asserts successful creation with the expected (and, where applicable, forbidden) output.
