### PR TITLE
test: add conformance tests for environment template validation

### DIFF
--- a/conformance-tests/2023-09/EXPR/env_templates/3.6--let-duplicate-name.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/env_templates/3.6--let-duplicate-name.invalid.yaml
@@ -1,0 +1,16 @@
+# Duplicate 'let' binding names in an EnvironmentScript must fail validation (spec 3.6).
+specificationVersion: environment-2023-09
+extensions:
+- EXPR
+environment:
+  name: TestEnv
+  script:
+    let:
+    - x = 1
+    - x = 2
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/env_templates/4.2--let-undefined-variable.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/env_templates/4.2--let-undefined-variable.invalid.yaml
@@ -1,0 +1,15 @@
+# A 'let' binding referencing an undefined variable must fail validation.
+specificationVersion: environment-2023-09
+extensions:
+- EXPR
+environment:
+  name: TestEnv
+  script:
+    let:
+    - x = Param.DoesNotExist + 1
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/env_templates/7.3.1--step-name-in-let.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/env_templates/7.3.1--step-name-in-let.invalid.yaml
@@ -1,0 +1,18 @@
+# Step.Name is scoped to the Step Template and is not available in an
+# <EnvironmentScript>.let binding (Template Schemas §3.6.2). A standalone
+# environment template has no enclosing Step, so referencing Step.Name in a let
+# binding value must fail validation. (Job.Name, by contrast, is valid here.)
+specificationVersion: environment-2023-09
+extensions:
+- EXPR
+environment:
+  name: TestEnv
+  script:
+    let:
+    - tag = Step.Name
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ tag }}')"

--- a/conformance-tests/2023-09/EXPR/env_templates/7.3.1--step-name-not-available.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/env_templates/7.3.1--step-name-not-available.invalid.yaml
@@ -1,0 +1,15 @@
+# Step.Name is scoped to the Step Template (spec 7.3.1). A standalone
+# environment template is not attached to a step, so Step.Name is undefined
+# even with EXPR.
+specificationVersion: environment-2023-09
+extensions:
+- EXPR
+environment:
+  name: TestEnv
+  script:
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ Step.Name }}')"

--- a/conformance-tests/2023-09/EXPR/env_templates/expr-env-template-features.yaml
+++ b/conformance-tests/2023-09/EXPR/env_templates/expr-env-template-features.yaml
@@ -1,0 +1,33 @@
+# EXPR features that are all valid together in an environment template:
+# - let bindings (spec 4.2) chaining session symbols and job parameters
+# - full expressions (spec 7.3) in variables, actions, and embedded files
+# - Job.Name (spec 7.3.1) — the environment runs inside some job's session
+specificationVersion: environment-2023-09
+extensions:
+- EXPR
+parameterDefinitions:
+- name: SubDir
+  type: STRING
+  default: output
+- name: X
+  type: INT
+  default: 5
+environment:
+  name: TestEnv
+  variables:
+    DOUBLED: "{{ Param.X * 2 }}"
+    JOB: "{{ Job.Name.upper() }}"
+  script:
+    let:
+    - work_dir = Session.WorkingDirectory / Param.SubDir
+    - log_file = work_dir / (Job.Name + '.log')
+    embeddedFiles:
+    - name: setup
+      type: TEXT
+      data: "value={{ Param.X + 1 }} log={{ log_file }}"
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ Param.X if Param.X > 0 else 0 }}')"

--- a/conformance-tests/2023-09/EXPR/env_templates/expr1.1--type-error.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/env_templates/expr1.1--type-error.invalid.yaml
@@ -1,0 +1,18 @@
+# Type errors in environment template expressions are caught at validation
+# time using declared parameter types (Expression Language 1.1).
+specificationVersion: environment-2023-09
+extensions:
+- EXPR
+parameterDefinitions:
+- name: Name
+  type: STRING
+  default: hello
+environment:
+  name: TestEnv
+  script:
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ Param.Name + 1 }}')"

--- a/conformance-tests/2023-09/EXPR/job_templates/3.6--let-in-job-environment-requires-expr.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/3.6--let-in-job-environment-requires-expr.invalid.yaml
@@ -1,0 +1,23 @@
+# EnvironmentScript 'let' in a job environment requires the EXPR extension (spec 4.2).
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+jobEnvironments:
+- name: Setup
+  script:
+    let:
+    - x = 1
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print()"
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/3.6--let-in-step-environment-requires-expr.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/3.6--let-in-step-environment-requires-expr.invalid.yaml
@@ -1,0 +1,23 @@
+# EnvironmentScript 'let' in a step environment requires the EXPR extension (spec 4.2).
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+steps:
+- name: Step1
+  stepEnvironments:
+  - name: Setup
+    script:
+      let:
+      - x = 1
+      actions:
+        onEnter:
+          command: python
+          args:
+          - "-c"
+          - "print()"
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/7.3--apply-path-mapping-in-timeout.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/7.3--apply-path-mapping-in-timeout.invalid.yaml
@@ -1,0 +1,23 @@
+# apply_path_mapping is a host function: path mapping rules only exist at
+# task execution. timeout is a plain @fmtstring resolved at job creation,
+# so host functions are not available in it — even though the same call is
+# valid in the action's command/args (@fmtstring[host]).
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+- FEATURE_BUNDLE_1
+name: TestJob
+parameterDefinitions:
+- name: Val
+  type: PATH
+  default: /tmp/x
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        timeout: "{{ len(apply_path_mapping(Param.Val)) }}"
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/7.3--complex-expr-in-env-action-requires-expr.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/7.3--complex-expr-in-env-action-requires-expr.invalid.yaml
@@ -1,0 +1,26 @@
+# Without the EXPR extension, format strings in environment script actions only
+# permit bare value references (spec 7.3). An arithmetic expression must be rejected.
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+parameterDefinitions:
+- name: X
+  type: INT
+  default: 5
+jobEnvironments:
+- name: Setup
+  script:
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ Param.X + 1 }}')"
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/7.3--complex-expr-in-env-variables-requires-expr.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/7.3--complex-expr-in-env-variables-requires-expr.invalid.yaml
@@ -1,0 +1,21 @@
+# Without the EXPR extension, format strings in environment variables only
+# permit bare value references (spec 7.3). An arithmetic expression must be rejected.
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+parameterDefinitions:
+- name: X
+  type: INT
+  default: 5
+jobEnvironments:
+- name: Setup
+  variables:
+    DOUBLED: "{{ Param.X * 2 }}"
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/7.3.1--job-step-name-in-step-let.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/7.3.1--job-step-name-in-step-let.yaml
@@ -1,0 +1,34 @@
+# Job.Name and Step.Name are both concrete before let bindings evaluate, so they
+# may be referenced in the value of a let binding at every Step-side scope
+# (Template Schemas §3.6.2): <StepTemplate>.let, <StepScript>.let, and
+# <SimpleAction>.let.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+- FEATURE_BUNDLE_1
+name: TestJob
+steps:
+- name: Render
+  # --- <StepTemplate>.let referencing Job.Name and Step.Name ---
+  let:
+  - job_tag = Job.Name + '/' + Step.Name
+  script:
+    # --- <StepScript>.let referencing Job.Name and Step.Name ---
+    let:
+    - script_tag = Job.Name + ':' + Step.Name
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ script_tag }}')"
+    embeddedFiles:
+    - name: summary
+      type: TEXT
+      data: "template={{ job_tag }} script={{ script_tag }}"
+- name: Package
+  bash:
+    # --- <SimpleAction>.let referencing Job.Name and Step.Name ---
+    let:
+    - action_tag = Job.Name + '-' + Step.Name
+    script: "echo {{ action_tag }}"

--- a/conformance-tests/2023-09/EXPR/job_templates/7.3.1--step-name-in-job-environment-let.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/7.3.1--step-name-in-job-environment-let.invalid.yaml
@@ -1,0 +1,27 @@
+# Step.Name is scoped to the Step Template, so it is not available in the let
+# bindings of a job-level environment's <EnvironmentScript> (Template Schemas
+# §3.6.2). Job.Name is fine here; Step.Name is not, because a jobEnvironment has
+# no enclosing Step.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+jobEnvironments:
+- name: Setup
+  script:
+    let:
+    - tag = Step.Name
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ tag }}')"
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: echo
+        args:
+        - hello

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/env_templates/1.2--fb1-features.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/env_templates/1.2--fb1-features.yaml
@@ -1,0 +1,28 @@
+# FEATURE_BUNDLE_1 features that are all valid together in an environment
+# template:
+# - timeout as a format string referencing a job parameter (spec 5) — job
+#   parameters are known at job creation, when timeout is resolved
+# - endOfLine on an embedded file (spec 6.1)
+specificationVersion: environment-2023-09
+extensions:
+- FEATURE_BUNDLE_1
+parameterDefinitions:
+- name: TimeoutSeconds
+  type: INT
+  minValue: 1
+  default: 30
+environment:
+  name: TestEnv
+  script:
+    embeddedFiles:
+    - name: setup
+      type: TEXT
+      data: "line1\nline2\n"
+      endOfLine: LF
+    actions:
+      onEnter:
+        timeout: "{{Param.TimeoutSeconds}}"
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/env_templates/5--timeout-env-file-reference.invalid.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/env_templates/5--timeout-env-file-reference.invalid.yaml
@@ -1,0 +1,20 @@
+# Env.File.* values only exist at task execution (the file is written to the
+# session working directory), but timeout is resolved at job creation. The
+# reference must be rejected even though it is valid in command/args.
+specificationVersion: environment-2023-09
+extensions:
+- FEATURE_BUNDLE_1
+environment:
+  name: TestEnv
+  script:
+    embeddedFiles:
+    - name: setup
+      type: TEXT
+      data: "echo entering"
+    actions:
+      onEnter:
+        timeout: "{{Env.File.setup}}"
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/env_templates/5--timeout-session-symbol.invalid.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/env_templates/5--timeout-session-symbol.invalid.yaml
@@ -1,0 +1,16 @@
+# timeout is a plain @fmtstring, resolved at job creation. Session.* values
+# only exist at task execution, so the reference must be rejected — even
+# though Session.* is valid in the same environment's command/args/variables.
+specificationVersion: environment-2023-09
+extensions:
+- FEATURE_BUNDLE_1
+environment:
+  name: TestEnv
+  script:
+    actions:
+      onEnter:
+        timeout: "{{Session.WorkingDirectory}}"
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/env_templates/6.1--end-of-line-without-extension.invalid.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/env_templates/6.1--end-of-line-without-extension.invalid.yaml
@@ -1,0 +1,16 @@
+# endOfLine on an environment template embedded file requires FEATURE_BUNDLE_1 (spec 6.1).
+specificationVersion: environment-2023-09
+environment:
+  name: TestEnv
+  script:
+    embeddedFiles:
+    - name: setup
+      type: TEXT
+      data: "line1\nline2\n"
+      endOfLine: LF
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--env-action-timeout-format-string.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--env-action-timeout-format-string.yaml
@@ -1,0 +1,31 @@
+# A timeout format string on an environment action referencing a job
+# parameter is valid: job parameters are known at job creation, which is
+# when timeout is resolved.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- FEATURE_BUNDLE_1
+name: TestJob
+parameterDefinitions:
+- name: TimeoutSeconds
+  type: INT
+  minValue: 1
+  default: 30
+jobEnvironments:
+- name: Setup
+  script:
+    actions:
+      onEnter:
+        timeout: "{{Param.TimeoutSeconds}}"
+        command: python
+        args:
+        - "-c"
+        - "print()"
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--env-action-timeout-session-symbol.invalid.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--env-action-timeout-session-symbol.invalid.yaml
@@ -1,0 +1,27 @@
+# timeout on an environment action is a plain @fmtstring, resolved at job
+# creation. Session.* values only exist at task execution, so the reference
+# must be rejected even in an environment context where Session.* is valid
+# in the action's command/args.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- FEATURE_BUNDLE_1
+name: TestJob
+jobEnvironments:
+- name: Setup
+  script:
+    actions:
+      onEnter:
+        timeout: "{{Session.WorkingDirectory}}"
+        command: python
+        args:
+        - "-c"
+        - "print()"
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--env-action-timeout-undefined-variable.invalid.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--env-action-timeout-undefined-variable.invalid.yaml
@@ -1,0 +1,25 @@
+# A timeout format string on an environment action referencing an undefined
+# variable must fail validation, like any other format string reference.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- FEATURE_BUNDLE_1
+name: TestJob
+jobEnvironments:
+- name: Setup
+  script:
+    actions:
+      onEnter:
+        timeout: "{{Param.DoesNotExist}}"
+        command: python
+        args:
+        - "-c"
+        - "print()"
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--notify-period-session-symbol.invalid.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--notify-period-session-symbol.invalid.yaml
@@ -1,0 +1,19 @@
+# notifyPeriodInSeconds is a plain @fmtstring: it is resolved at job creation,
+# before any session exists. Session.* values only exist at task execution, so
+# a notify period referencing one must be rejected.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- FEATURE_BUNDLE_1
+name: TestJob
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"
+        cancelation:
+          mode: NOTIFY_THEN_TERMINATE
+          notifyPeriodInSeconds: "{{Session.WorkingDirectory}}"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--timeout-session-symbol.invalid.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/job_templates/5--timeout-session-symbol.invalid.yaml
@@ -1,0 +1,18 @@
+# timeout is a plain @fmtstring: it is resolved at job creation, before any
+# session exists. Session.* values only exist at task execution, so a timeout
+# referencing one must be rejected — even though the same reference is valid
+# in the action's command/args (@fmtstring[host]).
+specificationVersion: jobtemplate-2023-09
+extensions:
+- FEATURE_BUNDLE_1
+name: TestJob
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        timeout: "{{Session.WorkingDirectory}}"
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/base/env_templates/4.2--let-requires-expr.invalid.yaml
+++ b/conformance-tests/2023-09/base/env_templates/4.2--let-requires-expr.invalid.yaml
@@ -1,0 +1,13 @@
+# EnvironmentScript 'let' requires the EXPR extension (spec 4.2).
+specificationVersion: environment-2023-09
+environment:
+  name: TestEnv
+  script:
+    let:
+    - x = 1
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/base/env_templates/7.3--complex-expr-requires-expr.invalid.yaml
+++ b/conformance-tests/2023-09/base/env_templates/7.3--complex-expr-requires-expr.invalid.yaml
@@ -1,0 +1,16 @@
+# Without the EXPR extension, format strings only permit bare value references
+# (spec 7.3). An arithmetic expression must be rejected.
+specificationVersion: environment-2023-09
+parameterDefinitions:
+- name: X
+  type: INT
+  default: 5
+environment:
+  name: TestEnv
+  script:
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ Param.X + 1 }}')"

--- a/conformance-tests/2023-09/base/env_templates/7.3--undefined-variable-in-args.invalid.yaml
+++ b/conformance-tests/2023-09/base/env_templates/7.3--undefined-variable-in-args.invalid.yaml
@@ -1,0 +1,11 @@
+# A format string referencing an undefined variable in action args must fail validation.
+specificationVersion: environment-2023-09
+environment:
+  name: TestEnv
+  script:
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ Param.DoesNotExist }}')"

--- a/conformance-tests/2023-09/base/env_templates/7.3--undefined-variable-in-command.invalid.yaml
+++ b/conformance-tests/2023-09/base/env_templates/7.3--undefined-variable-in-command.invalid.yaml
@@ -1,0 +1,8 @@
+# A format string referencing an undefined variable must fail validation.
+specificationVersion: environment-2023-09
+environment:
+  name: TestEnv
+  script:
+    actions:
+      onEnter:
+        command: "{{ Param.DoesNotExist }}"

--- a/conformance-tests/2023-09/base/env_templates/7.3--undefined-variable-in-embedded-file.invalid.yaml
+++ b/conformance-tests/2023-09/base/env_templates/7.3--undefined-variable-in-embedded-file.invalid.yaml
@@ -1,0 +1,15 @@
+# A format string referencing an undefined variable in embedded file data must fail validation.
+specificationVersion: environment-2023-09
+environment:
+  name: TestEnv
+  script:
+    embeddedFiles:
+    - name: setup
+      type: TEXT
+      data: "value is {{ Param.DoesNotExist }}"
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/base/env_templates/7.3--undefined-variable-in-variables.invalid.yaml
+++ b/conformance-tests/2023-09/base/env_templates/7.3--undefined-variable-in-variables.invalid.yaml
@@ -1,0 +1,6 @@
+# A format string referencing an undefined variable in environment variables must fail validation.
+specificationVersion: environment-2023-09
+environment:
+  name: TestEnv
+  variables:
+    MY_VAR: "{{ Param.DoesNotExist }}"

--- a/conformance-tests/2023-09/base/env_templates/7.3.1--job-name-requires-expr.invalid.yaml
+++ b/conformance-tests/2023-09/base/env_templates/7.3.1--job-name-requires-expr.invalid.yaml
@@ -1,0 +1,11 @@
+# Job.Name requires the EXPR extension. Without it, this is an undefined variable.
+specificationVersion: environment-2023-09
+environment:
+  name: TestEnv
+  script:
+    actions:
+      onEnter:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ Job.Name }}')"

--- a/conformance-tests/2023-09/base/env_templates/7.3.1--value-references.yaml
+++ b/conformance-tests/2023-09/base/env_templates/7.3.1--value-references.yaml
@@ -1,0 +1,23 @@
+# Value references available in environment template format strings (spec 7.3.1):
+# Session.* in variables, actions, and embedded files; Env.File.<name> resolving
+# to this environment's embedded files.
+specificationVersion: environment-2023-09
+environment:
+  name: TestEnv
+  variables:
+    WORKDIR: "{{ Session.WorkingDirectory }}"
+    HAS_RULES: "{{ Session.HasPathMappingRules }}"
+  script:
+    embeddedFiles:
+    - name: setup
+      type: TEXT
+      runnable: true
+      data: "#!/usr/bin/env bash\necho workdir={{ Session.WorkingDirectory }}\n"
+    actions:
+      onEnter:
+        command: "{{ Env.File.setup }}"
+      onExit:
+        command: python
+        args:
+        - "-c"
+        - "print(r'{{ Session.PathMappingRulesFile }}')"

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -1457,10 +1457,10 @@ and where the bound names are available:
 
 | Location | Can Reference | Bound Names Available In |
 |----------|---------------|--------------------------|
-| `<StepTemplate>.let` | `Param.*`, `RawParam.*`, earlier bindings in same `let` | *stepEnvironments*, *hostRequirements*, *parameterSpace*, *script* (including nested `<StepScript>.let` or `<SimpleAction>.let`) |
-| `<StepScript>.let` | `Param.*`, `RawParam.*`, `Task.Param.*`, `Task.RawParam.*`, `Session.*`, step-level bindings, earlier bindings in same `let` | *actions*, *embeddedFiles* |
-| `<SimpleAction>.let` | `Param.*`, `RawParam.*`, `Task.Param.*`, `Task.RawParam.*`, `Session.*`, step-level bindings, earlier bindings in same `let` | *script*, *args* |
-| `<EnvironmentScript>.let` | `Param.*`, `RawParam.*`, `Session.*`, `Env.File.*`, earlier bindings in same `let` | *actions*, *embeddedFiles* |
+| `<StepTemplate>.let` | `Param.*`, `RawParam.*`, `Job.Name`, `Step.Name`, earlier bindings in same `let` | *stepEnvironments*, *hostRequirements*, *parameterSpace*, *script* (including nested `<StepScript>.let` or `<SimpleAction>.let`) |
+| `<StepScript>.let` | `Param.*`, `RawParam.*`, `Task.Param.*`, `Task.RawParam.*`, `Session.*`, `Job.Name`, `Step.Name`, step-level bindings, earlier bindings in same `let` | *actions*, *embeddedFiles* |
+| `<SimpleAction>.let` | `Param.*`, `RawParam.*`, `Task.Param.*`, `Task.RawParam.*`, `Session.*`, `Job.Name`, `Step.Name`, step-level bindings, earlier bindings in same `let` | *script*, *args* |
+| `<EnvironmentScript>.let` | `Param.*`, `RawParam.*`, `Session.*`, `Env.File.*`, `Job.Name`, earlier bindings in same `let` | *actions*, *embeddedFiles* |
 
 Note: `Task.Param.*` and `Task.RawParam.*` are only available in `<StepScript>` and `<SimpleAction>` contexts because task parameter
 values are not known until task execution time.
@@ -1468,6 +1468,11 @@ values are not known until task execution time.
 Note: `Env.File.*` symbols in `<EnvironmentScript>.let` refer to embedded files defined in the same `<EnvironmentScript>`.
 The file path is determined before evaluation, so `let` bindings can reference the path where the file will be written,
 even though the file content (which may also contain format strings) is evaluated separately.
+
+Note: `Job.Name` is concrete at job creation, so it is available in every `let` scope. `Step.Name` is scoped to the
+Step Template (see [7.3.1](#731-value-references)), so it is available in the Step-side `let` scopes but not in
+`<EnvironmentScript>.let`, which may also appear in a Job-level environment or a standalone environment template where
+no enclosing Step exists.
 
 ## 4. `<Environment>`
 


### PR DESCRIPTION
Environment templates share the format-string, EXPR, and FEATURE_BUNDLE_1 rules with job templates, but the suite had no coverage for them; implementations could skip those passes for environment templates entirely and still pass.

- base/env_templates: undefined variable references in actions, variables, and embedded files must be rejected; Session.* and Env.File.* references are valid; Job.Name, let bindings, and complex expressions require EXPR.
- EXPR/env_templates (new): let bindings valid/duplicate/undefined, complex expressions, Job.Name available, Step.Name not available, type errors caught at validation time.
- FEATURE_BUNDLE_1/env_templates (new): endOfLine on embedded files requires the extension.
- EXPR/job_templates: environment script let bindings and complex expressions in job/step environments require EXPR (previously only step-level let was covered).

Also cover the @fmtstring stage rule (spec 7.4) for timeout and notifyPeriodInSeconds: they resolve at job creation, before any session exists, so Session.*, Env.File.*, and host functions like apply_path_mapping must be rejected in them even though the same references are valid in the surrounding action's command/args (@fmtstring[host]). Covered for step actions, environment actions in job templates, and environment templates.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
