### PR TITLE
feat: Polish up RFC 0008 and address follow-up review comments

### DIFF
--- a/conformance-tests/2023-09/WRAP_ACTIONS/README.md
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/README.md
@@ -26,7 +26,7 @@ the `WrappedAction.*` template variables:
 | `WrappedAction.Command`       | `string`       | The `command` from the wrapped action                               |
 | `WrappedAction.Args`          | `list[string]` | The `args` from the wrapped action                                  |
 | `WrappedAction.Environment`   | `list[string]` | `openjd_env`-defined variables as `["KEY=value", ...]`              |
-| `WrappedAction.Timeout`       | `int`          | Timeout of the wrapped action in seconds, or `0` if none            |
+| `WrappedAction.Timeout`       | `int?`         | Timeout of the wrapped action in seconds; `null` if none            |
 | `WrappedEnv.Name`             | `string`       | Name of the inner environment (only in `onWrapEnvEnter`/`onWrapEnvExit`)  |
 | `WrappedStep.Name`            | `string`       | Name of the step whose task is being wrapped (only in `onWrapTaskRun`) |
 
@@ -72,6 +72,7 @@ WRAP_ACTIONS/
 │   ├── 4.2--wrap-only-environment.yaml
 │   ├── 4.2--wrap-with-timeout.yaml
 │   ├── 4.2--empty-actions-no-wrap-no-enter-no-exit.invalid.yaml
+│   ├── 4.2--wrap-fmtstring-timeout-no-feature-bundle.invalid.yaml
 │   ├── 4.3--wrap-only-onwrap-task-run.invalid.yaml
 │   └── 4.3--wrap-missing-onwrap-exit.invalid.yaml
 └── jobs/                           # End-to-end execution tests
@@ -91,10 +92,24 @@ WRAP_ACTIONS/
     ├── wrap-task-args-preserved.test.yaml
     ├── wrap-task-environment-injected.test.yaml
     ├── wrap-task-action-timeout-injected.test.yaml
-    ├── wrap-task-action-timeout-zero-when-unset.test.yaml
+    ├── wrap-task-action-timeout-null-when-unset.test.yaml
     ├── wrap-timeout-injected-python.test.yaml
     ├── wrap-no-args.test.yaml
     ├── wrap-empty-environment-list.test.yaml
+    ├── wrap-cancelation-mode-terminate.test.yaml
+    ├── wrap-cancelation-mode-notify-then-terminate.test.yaml
+    ├── wrap-cancelation-mode-null-when-no-cancelation.test.yaml
+    ├── wrap-cancelation-notify-period-injected.test.yaml
+    ├── wrap-cancelation-notify-period-defaults-onrun-120.test.yaml
+    ├── wrap-cancelation-notify-period-defaults-onenter-30.test.yaml
+    ├── wrap-cancelation-notify-period-defaults-onexit-30.test.yaml
+    ├── wrap-cancelation-notify-period-null-when-terminate.test.yaml
+    ├── wrap-cancelation-notify-period-null-when-no-cancelation.test.yaml
+    ├── wrap-cancelation-roundtrip-notify-then-terminate.test.yaml
+    ├── wrap-cancelation-roundtrip-terminate.test.yaml
+    ├── wrap-cancelation-roundtrip-no-cancelation.test.yaml
+    ├── wrap-cancelation-roundtrip-period-only.test.yaml
+    ├── wrap-cancelation-partial-fmtstring-mode.test.yaml
     ├── wrap-openjd-env-from-wrapped-onenter-propagates.test.yaml
     │  # Exit-status propagation
     ├── wrap-exit-status-propagates.test.yaml
@@ -116,6 +131,7 @@ WRAP_ACTIONS/
     │  # Invalid templates / sessions the runner must reject
     ├── wrap-without-extension-fails.invalid.test.yaml
     ├── wrap-without-expr-extension.invalid.test.yaml
+    ├── wrap-cancelation-fmtstring-mode-no-feature-bundle.invalid.test.yaml
     ├── wrap-multiple-wrap-envs-rejected.invalid.test.yaml
     ├── wrap-job-and-step-env-rejected.invalid.test.yaml
     ├── wrap-partial-hooks-rejected.invalid.test.yaml
@@ -165,13 +181,53 @@ bundles in this directory:
   reach the wrap script with the right values
   (`wrap-task-command-injected`, `wrap-task-args-preserved`,
   `wrap-task-environment-injected`, `wrap-task-action-timeout-injected`,
-  `wrap-no-args`, `wrap-empty-environment-list`), and `WrappedAction.*` is
+  `wrap-timeout-injected-python`, `wrap-no-args`,
+  `wrap-empty-environment-list`), and `WrappedAction.*` is
   in scope in the env-lifecycle hooks too
   (`wrap-enter-receives-wrapped-action`,
   `wrap-exit-receives-wrapped-action`).
-- **Timeout sentinel**: `WrappedAction.Timeout` is `0` when the wrapped
-  action specifies no timeout (`wrap-task-action-timeout-zero-when-unset`,
-  `wrap-timeout-injected-python`).
+- **Timeout nullability**: `WrappedAction.Timeout` (typed `int?`) is `null`
+  when the wrapped action specifies no timeout — rendering empty in
+  interpolation and observable via EXPR null-coalescing
+  (`wrap-task-action-timeout-null-when-unset`).
+- **Cancelation mode injection**: `WrappedAction.Cancelation.Mode` (typed
+  `string?`) carries `TERMINATE` (`wrap-cancelation-mode-terminate`),
+  `NOTIFY_THEN_TERMINATE` (`wrap-cancelation-mode-notify-then-terminate`),
+  or `null` when the wrapped action defines no `<Cancelation>` — rendering
+  empty in interpolation and observable via EXPR null-coalescing
+  (`wrap-cancelation-mode-null-when-no-cancelation`).
+- **Cancelation notify-period injection**:
+  `WrappedAction.Cancelation.NotifyPeriodInSeconds` (typed `int?`) carries
+  the effective grace period when the wrapped action's mode is
+  `NOTIFY_THEN_TERMINATE` — including the runtime-supplied schema default
+  when the wrapped action omits the field (120 on a task's `onRun`, 30
+  otherwise) — and is `null` otherwise:
+  - `wrap-cancelation-notify-period-injected` (explicit value)
+  - `wrap-cancelation-notify-period-defaults-onrun-120` (schema default on a task)
+  - `wrap-cancelation-notify-period-defaults-onenter-30` (schema default on an env `onEnter`)
+  - `wrap-cancelation-notify-period-defaults-onexit-30` (schema default on an env `onExit`)
+  - `wrap-cancelation-notify-period-null-when-terminate` (null when `TERMINATE`)
+  - `wrap-cancelation-notify-period-null-when-no-cancelation` (null when no `<Cancelation>`)
+- **Cancelation + timeout round-trip forwarding** (Template Schemas §5.3
+  and §5, FEATURE_BUNDLE_1): a wrap hook adopts the wrapped action's
+  cancelation and timeout as its own via whole-field expressions
+  (`mode: "{{WrappedAction.Cancelation.Mode}}"` /
+  `notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"` /
+  `timeout: "{{WrappedAction.Timeout}}"`),
+  with null-forwarding per RFC 0005 expression evaluation types (a null
+  timeout or notify period drops the field; a null mode drops the whole
+  `cancelation` object):
+  - `wrap-cancelation-roundtrip-notify-then-terminate` (both fields forwarded verbatim)
+  - `wrap-cancelation-roundtrip-terminate` (null period drops the field)
+  - `wrap-cancelation-roundtrip-no-cancelation` (null mode drops the whole `cancelation` object)
+  - `wrap-cancelation-roundtrip-period-only` (literal mode, forwarded period —
+    already legal under FEATURE_BUNDLE_1's `@fmtstring` notify period)
+  - `wrap-cancelation-fmtstring-mode-no-feature-bundle` (invalid: the
+    format-string `mode` form requires FEATURE_BUNDLE_1)
+  - `wrap-cancelation-partial-fmtstring-mode` (a format-string `mode` gets
+    normal format string behavior — partial interpolation like
+    `"{{ ... }}_THEN_TERMINATE"` is valid; the resolved value is checked
+    against the two mode names at run time)
 - **`openjd_env` propagation**: variables emitted by a wrapped `onEnter`
   surface in `WrappedAction.Environment` for subsequent wrapped actions
   (`wrap-openjd-env-from-wrapped-onenter-propagates`).
@@ -201,6 +257,9 @@ bundles in this directory:
   - `4.3--wrap-missing-onwrap-exit`: all-or-nothing rule (env side).
   - `4.2--empty-actions-no-wrap-no-enter-no-exit`: an `actions` block must
     define at least one action.
+  - `4.2--wrap-fmtstring-timeout-no-feature-bundle`: a format-string `timeout`
+    on a wrap hook requires `FEATURE_BUNDLE_1`; without it the hook `timeout`
+    must be a plain positive integer.
 
 ## Running the tests
 

--- a/conformance-tests/2023-09/WRAP_ACTIONS/env_templates/4.2--wrap-fmtstring-timeout-no-feature-bundle.invalid.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/env_templates/4.2--wrap-fmtstring-timeout-no-feature-bundle.invalid.yaml
@@ -1,0 +1,27 @@
+# RFC 0008: a wrap hook's `timeout` is a plain positive integer. A format
+# string there is only valid with the FEATURE_BUNDLE_1 extension, which this
+# template does not declare, so validation must reject it. Forwarding
+# WrappedAction.Timeout into the hook's own timeout field (the variable is
+# int?; a null result drops the field so the hook default applies) is
+# therefore only available under FEATURE_BUNDLE_1 — see the
+# wrap-cancelation-roundtrip-* job tests for the gated round-trip behavior.
+specificationVersion: environment-2023-09
+extensions:
+- WRAP_ACTIONS
+- EXPR
+environment:
+  name: WrapFmtStringTimeout
+  script:
+    actions:
+      onWrapEnvEnter:
+        command: echo
+        args: ["{{WrappedEnv.Name}}"]
+        timeout: "{{WrappedAction.Timeout}}"
+      onWrapTaskRun:
+        command: echo
+        args: ["{{WrappedAction.Command}}"]
+        timeout: "{{WrappedAction.Timeout}}"
+      onWrapEnvExit:
+        command: echo
+        args: ["{{WrappedEnv.Name}}"]
+        timeout: "{{WrappedAction.Timeout}}"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-fmtstring-mode-no-feature-bundle.invalid.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-fmtstring-mode-no-feature-bundle.invalid.test.yaml
@@ -1,0 +1,46 @@
+# Template Schemas 5.3: the format-string form of a <CancelationMethod>
+# mode is gated on the FEATURE_BUNDLE_1 extension. A template using
+# mode: "{{...}}" with only WRAP_ACTIONS and EXPR declared must be
+# rejected.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationFmtstringModeNoFeatureBundle
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: TERMINATE
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"should not run\""
+          cancelation:
+            mode: "{{WrappedAction.Cancelation.Mode}}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-mode-notify-then-terminate.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-mode-notify-then-terminate.test.yaml
@@ -1,0 +1,49 @@
+# RFC 0008: WrappedAction.Cancelation.Mode surfaces the wrapped action's
+# cancelation method. When the wrapped action declares
+# <CancelationMethodNotifyThenTerminate>, Mode is the string
+# `NOTIFY_THEN_TERMINATE`.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionCancelationModeNotifyThenTerminate
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: 60
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"MODE=<{{WrappedAction.Cancelation.Mode}}>\""
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "MODE=<NOTIFY_THEN_TERMINATE>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-mode-null-when-no-cancelation.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-mode-null-when-no-cancelation.test.yaml
@@ -1,0 +1,54 @@
+# RFC 0008: WrappedAction.Cancelation.Mode is `null` when the wrapped
+# action defines no <Cancelation>. Note this differs from the runtime's
+# default cancelation-method semantics: at runtime, an action with no
+# <Cancelation> is treated as `<CancelationMethodTerminate>` (Template
+# Schemas 5), but the template variable itself carries `null` — the "not
+# declared" value for optional data — so wrap scripts can distinguish
+# "author explicitly asked for TERMINATE" from "author declared nothing".
+# Interpolated into a format string, null renders as the empty string
+# (MODE=<>); EXPR's null-coalescing `or` makes the nullness observable
+# (COALESCED=<UNDECLARED>).
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionCancelationModeNullWhenNoCancelation
+  steps:
+  - name: Step1
+    script:
+      actions:
+        # No cancelation: block at all.
+        onRun:
+          command: echo
+          args: ["placeholder"]
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"MODE=<{{WrappedAction.Cancelation.Mode}}>\"; echo \"COALESCED=<{{ WrappedAction.Cancelation.Mode or 'UNDECLARED' }}>\""
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "MODE=<>"
+  - "COALESCED=<UNDECLARED>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-mode-terminate.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-mode-terminate.test.yaml
@@ -1,0 +1,47 @@
+# RFC 0008: WrappedAction.Cancelation.Mode surfaces the wrapped action's
+# cancelation method. When the wrapped action declares
+# <CancelationMethodTerminate>, Mode is the string `TERMINATE`.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionCancelationModeTerminate
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: TERMINATE
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"MODE=<{{WrappedAction.Cancelation.Mode}}>\""
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "MODE=<TERMINATE>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-defaults-onenter-30.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-defaults-onenter-30.test.yaml
@@ -1,0 +1,65 @@
+# RFC 0008: when the wrapped action's mode is NOTIFY_THEN_TERMINATE and it
+# omits notifyPeriodInSeconds, the runtime supplies the schema default for
+# the action's position (Template Schemas 5.3.2).
+#
+# For anything other than a task's onRun — including an inner environment's
+# onEnter — the default is 30 seconds. This test exercises the "otherwise"
+# branch by wrapping an inner environment's onEnter and echoing the
+# forwarded notify period from onWrapEnvEnter.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionNotifyPeriodDefaultsOnEnter30
+  jobEnvironments:
+  - name: InnerEnv
+    script:
+      actions:
+        onEnter:
+          command: inner-enter-cmd
+          args: ["--flag"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            # No notifyPeriodInSeconds — expect runtime default 30 for a
+            # non-onRun action.
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["TASK"]
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          # The wrap replaces InnerEnv.onEnter entirely; the inner command
+          # is never invoked (inner-enter-cmd need not exist). We only
+          # observe the injected variable's value.
+          - "echo \"NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}>\""
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "true"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "NP=<30>"
+  - "TASK"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-defaults-onexit-30.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-defaults-onexit-30.test.yaml
@@ -1,0 +1,68 @@
+# RFC 0008: when the wrapped action's mode is NOTIFY_THEN_TERMINATE and it
+# omits notifyPeriodInSeconds, the runtime supplies the schema default for
+# the action's position (Template Schemas 5.3.2).
+#
+# For an inner environment's onExit the default is 30 seconds — the same
+# "otherwise" branch as onEnter. This test exists separately from the
+# onEnter variant because an implementation could plausibly special-case
+# per hook; the pair pins the default for both env-lifecycle positions.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionNotifyPeriodDefaultsOnExit30
+  jobEnvironments:
+  - name: InnerEnv
+    script:
+      actions:
+        onEnter:
+          command: echo
+          args: ["inner-enter"]
+        onExit:
+          command: inner-exit-cmd
+          args: ["--flag"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            # No notifyPeriodInSeconds — expect runtime default 30 for a
+            # non-onRun action.
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["TASK"]
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          # The wrap replaces InnerEnv.onExit entirely; inner-exit-cmd is
+          # never invoked. We only observe the injected variable's value.
+          - "echo \"NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}>\""
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "inner-enter"
+  - "TASK"
+  - "NP=<30>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-defaults-onrun-120.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-defaults-onrun-120.test.yaml
@@ -1,16 +1,23 @@
-# RFC 0008: when the wrapped action specifies no timeout, WrappedAction.Timeout
-# evaluates to 0 (the spec sentinel — `<posinteger>` cannot represent absence).
+# RFC 0008: when the wrapped action's mode is NOTIFY_THEN_TERMINATE and it
+# omits notifyPeriodInSeconds, the runtime supplies the schema default for
+# the action's position (Template Schemas 5.3.2:
+# `<CancelationMethodNotifyThenTerminate>`) so the wrap script always sees
+# the value the runtime would have enforced in the unwrapped case.
+#
+# For a task's onRun, the default is 120 seconds.
 template:
   specificationVersion: jobtemplate-2023-09
-  name: WrappedActionTimeoutZeroWhenUnset
+  name: WrappedActionNotifyPeriodDefaultsOnRun120
   steps:
   - name: Step1
     script:
       actions:
-        # Note: no timeout field on this onRun.
         onRun:
           command: echo
           args: ["placeholder"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            # Deliberately no notifyPeriodInSeconds — expect runtime default 120.
 
 environments:
 - specificationVersion: environment-2023-09
@@ -30,7 +37,7 @@ environments:
           command: bash
           args:
           - "-c"
-          - "echo TIMEOUT={{WrappedAction.Timeout}}"
+          - "echo \"NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}>\""
         onWrapEnvExit:
           command: bash
           args:
@@ -42,4 +49,4 @@ runOn:
 
 expected:
   output:
-  - TIMEOUT=0
+  - "NP=<120>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-injected.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-injected.test.yaml
@@ -1,0 +1,50 @@
+# RFC 0008: WrappedAction.Cancelation.NotifyPeriodInSeconds surfaces the
+# effective grace period from the wrapped action's <Cancelation> when the
+# mode is NOTIFY_THEN_TERMINATE. Explicit value must forward as-is.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionNotifyPeriodInjected
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: 45
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          # Use `<...>` sentinel wrap so an empty/null value renders as
+          # `NP=<>` unambiguously; a real value renders inside the brackets.
+          - "echo \"NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}>\""
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "NP=<45>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-null-when-no-cancelation.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-null-when-no-cancelation.test.yaml
@@ -1,0 +1,49 @@
+# RFC 0008: WrappedAction.Cancelation.NotifyPeriodInSeconds is `null` when
+# the wrapped action defines no <Cancelation> at all. This case is distinct
+# from mode=TERMINATE (which is exercised by
+# wrap-cancelation-notify-period-null-when-terminate): here, no cancelation
+# was declared, so both Mode (string?) and NotifyPeriodInSeconds (int?)
+# are null.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionNotifyPeriodNullWhenNoCancelation
+  steps:
+  - name: Step1
+    script:
+      actions:
+        # No cancelation: block at all.
+        onRun:
+          command: echo
+          args: ["placeholder"]
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}>\""
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "NP=<>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-null-when-terminate.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-notify-period-null-when-terminate.test.yaml
@@ -1,0 +1,51 @@
+# RFC 0008: WrappedAction.Cancelation.NotifyPeriodInSeconds is int? and is
+# `null` when the wrapped action's mode is TERMINATE (a notify period is
+# not meaningful in that case). In a format string, EXPR coerces `null`
+# to the empty string, so the sentinel wrap renders as `NP=<>`.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionNotifyPeriodNullWhenTerminate
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: TERMINATE
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}>\""
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  # `null` in a format string becomes the empty string. This distinguishes
+  # the int? null case from the old int-with-0-sentinel behavior, which
+  # would have rendered `NP=<0>`.
+  - "NP=<>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-partial-fmtstring-mode.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-partial-fmtstring-mode.test.yaml
@@ -1,0 +1,58 @@
+# Template Schemas 5.3 (FEATURE_BUNDLE_1): a format-string cancelation
+# mode gets normal format string behavior — partial interpolation like
+# "{{ ... }}_THEN_TERMINATE" is valid, and the resolved value is checked
+# against the two mode names when the runtime prepares to run the action.
+# Only a whole-field expression ("{{ ... }}" with no surrounding text)
+# additionally gets string? null semantics. Here the partial mode resolves
+# to "NOTIFY_THEN_TERMINATE" and the wrap action runs normally.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationPartialFmtstringMode
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: 45
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"PARTIAL MODE OK NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}>\""
+          cancelation:
+            # Partial interpolation ("{{ ... }}" followed by literal
+            # text): the segments concatenate to NOTIFY_THEN_TERMINATE.
+            mode: "{{ 'NOTIFY' }}_THEN_TERMINATE"
+            notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "PARTIAL MODE OK NP=<45>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-no-cancelation.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-no-cancelation.test.yaml
@@ -1,0 +1,57 @@
+# RFC 0008 + Template Schemas 5.3 (FEATURE_BUNDLE_1): cancelation round-trip
+# forwarding when the wrapped action declares no <Cancelation> at all. The
+# mode expression resolves to null, which drops the ENTIRE cancelation
+# object — mode is the object's required discriminator, so an omitted mode
+# cannot leave a partial object behind. The wrap action behaves exactly as
+# if its author had declared no <Cancelation> (runtime default: terminate),
+# and the null notify period is dropped along with it.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationRoundtripNoCancelation
+  steps:
+  - name: Step1
+    script:
+      actions:
+        # No cancelation: block at all.
+        onRun:
+          command: echo
+          args: ["placeholder"]
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"ROUNDTRIP MODE=<{{ WrappedAction.Cancelation.Mode or 'UNDECLARED' }}> NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}> T=<{{WrappedAction.Timeout}}>\""
+          # No timeout on the wrapped onRun: WrappedAction.Timeout is null,
+          # so the whole-field expression drops the field (hook default).
+          timeout: "{{WrappedAction.Timeout}}"
+          cancelation:
+            mode: "{{WrappedAction.Cancelation.Mode}}"
+            notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "ROUNDTRIP MODE=<UNDECLARED> NP=<> T=<>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-notify-then-terminate.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-notify-then-terminate.test.yaml
@@ -1,0 +1,65 @@
+# RFC 0008 + Template Schemas 5.3/5 (FEATURE_BUNDLE_1): a wrap hook can
+# adopt the wrapped action's cancelation and timeout as its own by
+# forwarding the fields as whole-field expressions:
+#
+#   timeout: "{{WrappedAction.Timeout}}"
+#   cancelation:
+#     mode: "{{WrappedAction.Cancelation.Mode}}"
+#     notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+#
+# Here the wrapped action declares NOTIFY_THEN_TERMINATE with an explicit
+# period and an explicit timeout, so the expressions resolve to the same
+# declared values and the wrap action runs under an equivalent
+# <Cancelation> and timeout. The template must be accepted and the task
+# must run via the wrap hook.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationRoundtripNotifyThenTerminate
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          timeout: 300
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: 45
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"ROUNDTRIP MODE=<{{WrappedAction.Cancelation.Mode}}> NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}> T=<{{WrappedAction.Timeout}}>\""
+          timeout: "{{WrappedAction.Timeout}}"
+          cancelation:
+            mode: "{{WrappedAction.Cancelation.Mode}}"
+            notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "ROUNDTRIP MODE=<NOTIFY_THEN_TERMINATE> NP=<45> T=<300>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-period-only.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-period-only.test.yaml
@@ -1,0 +1,56 @@
+# RFC 0008 + Template Schemas 5.3.2 (FEATURE_BUNDLE_1): the narrower
+# round-trip — a literal NOTIFY_THEN_TERMINATE mode with only the notify
+# period forwarded as a whole-field expression. notifyPeriodInSeconds is
+# already @fmtstring under FEATURE_BUNDLE_1, so this must validate with the
+# WrappedAction.* variables in scope for the wrap hook's own cancelation
+# block, and the resolved value (45, forwarded from the wrapped action)
+# must be accepted.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationRoundtripPeriodOnly
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: 45
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"PERIOD-ONLY NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}>\""
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "PERIOD-ONLY NP=<45>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-terminate.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-terminate.test.yaml
@@ -1,0 +1,57 @@
+# RFC 0008 + Template Schemas 5.3 (FEATURE_BUNDLE_1): cancelation round-trip
+# forwarding when the wrapped action declares TERMINATE. The mode expression
+# resolves to "TERMINATE"; the notifyPeriodInSeconds expression resolves to
+# null, so per whole-field expression semantics (int?) the field is treated
+# as not provided — the wrap action's effective cancelation is plain
+# TERMINATE, exactly mirroring the wrapped action.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationRoundtripTerminate
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: TERMINATE
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"ROUNDTRIP MODE=<{{WrappedAction.Cancelation.Mode}}> NP=<{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}> T=<{{WrappedAction.Timeout}}>\""
+          # No timeout on the wrapped onRun: WrappedAction.Timeout is null,
+          # so the whole-field expression drops the field (hook default).
+          timeout: "{{WrappedAction.Timeout}}"
+          cancelation:
+            mode: "{{WrappedAction.Cancelation.Mode}}"
+            notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "ROUNDTRIP MODE=<TERMINATE> NP=<> T=<>"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-partial-hooks-rejected.invalid.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-partial-hooks-rejected.invalid.test.yaml
@@ -16,6 +16,9 @@ environments:
 - specificationVersion: environment-2023-09
   extensions:
   - WRAP_ACTIONS
+  # EXPR is declared so the missing-EXPR rule cannot mask the defect this
+  # test exercises: the only invalidity is the partial wrap-hook set.
+  - EXPR
   environment:
     name: PartialWrap
     script:

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-task-action-timeout-null-when-unset.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-task-action-timeout-null-when-unset.test.yaml
@@ -1,0 +1,51 @@
+# RFC 0008: when the wrapped action specifies no timeout,
+# WrappedAction.Timeout is `null` (the variable is typed int?, following
+# the EXPR semantics for optional data — the same convention as the
+# WrappedAction.Cancelation.* variables). Interpolated into a format
+# string, null renders as the empty string (TIMEOUT=<>); EXPR's
+# null-coalescing `or` makes the nullness observable
+# (TIMEOUT_OR=<NONE>).
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrappedActionTimeoutNullWhenUnset
+  steps:
+  - name: Step1
+    script:
+      actions:
+        # Note: no timeout field on this onRun.
+        onRun:
+          command: echo
+          args: ["placeholder"]
+
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"TIMEOUT=<{{WrappedAction.Timeout}}>\"; echo \"TIMEOUT_OR=<{{ WrappedAction.Timeout or 'NONE' }}>\""
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+
+runOn:
+- posix
+
+expected:
+  output:
+  - "TIMEOUT=<>"
+  - "TIMEOUT_OR=<NONE>"

--- a/rfcs/0008-environment-wrap-actions.md
+++ b/rfcs/0008-environment-wrap-actions.md
@@ -55,15 +55,12 @@ environment:
       onWrapEnvEnter:
         command: bash
         args: ["{{Env.File.Wrap}}"]
-        timeout: "{{WrappedAction.Timeout}}"
       onWrapTaskRun:
         command: bash
         args: ["{{Env.File.Wrap}}"]
-        timeout: "{{WrappedAction.Timeout}}"
       onWrapEnvExit:
         command: bash
         args: ["{{Env.File.Wrap}}"]
-        timeout: "{{WrappedAction.Timeout}}"
       onExit:
         command: bash
         args: ["{{Env.File.Exit}}"]
@@ -103,6 +100,15 @@ environment:
           set -euo pipefail
           docker container stop --timeout 30 "$DOCKER_CONTAINER_ID"
 ```
+
+The wrap hooks declare no `timeout`, so each inherits the default for its hook
+position (see [Timeout behavior](#timeout-behavior)). With the `FEATURE_BUNDLE_1`
+extension a hook may instead forward the wrapped action's timeout as its own
+via `timeout: "{{WrappedAction.Timeout}}"` — the variable is `int?`, so a
+declared timeout forwards verbatim and a `null` (no timeout on the wrapped
+action) drops the field, keeping the hook default. This example enforces the
+wrapped action's timeout from inside the wrap script instead (see
+[Timeout behavior](#timeout-behavior)).
 
 The job template that runs under this wrapping environment is unchanged from one
 that runs without wrapping. See the existing
@@ -290,8 +296,9 @@ helper scripts can be reused unchanged.
 | `WrappedAction.Command`           | `string`       | The `command` from the wrapped action. |
 | `WrappedAction.Args`              | `list[string]` | The `args` from the wrapped action. |
 | `WrappedAction.Environment`       | `list[string]` | Environment variables defined by `openjd_env` earlier in the session, as `["KEY=value", ...]`. See [Host environment variables and embedded file paths](#host-environment-variables-and-embedded-file-paths). |
-| `WrappedAction.Timeout`           | `int`          | The timeout in seconds specified on the wrapped action, or `0` if none. See [Timeout behavior](#timeout-behavior). |
-| `WrappedAction.Cancelation.Mode`  | `string`       | The cancelation method of the wrapped action (`TERMINATE` or `NOTIFY_THEN_TERMINATE`), or empty if the wrapped action defines no `<Cancelation>`. See [Cancelation behavior](#cancelation-behavior). |
+| `WrappedAction.Timeout`           | `int?`         | The timeout in seconds specified on the wrapped action. `null` when the wrapped action specifies no timeout — no bound is meaningful in that case. See [Timeout behavior](#timeout-behavior). |
+| `WrappedAction.Cancelation.Mode`  | `string?`      | The cancelation method of the wrapped action (`TERMINATE` or `NOTIFY_THEN_TERMINATE`). `null` when the wrapped action defines no `<Cancelation>` — the author declared nothing, so no method name is meaningful. See [Cancelation behavior](#cancelation-behavior). |
+| `WrappedAction.Cancelation.NotifyPeriodInSeconds` | `int?` | The effective `notifyPeriodInSeconds` of the wrapped action when its cancelation mode is `NOTIFY_THEN_TERMINATE`, with schema defaults applied when the wrapped action omits the field. `null` when the mode is `TERMINATE` or the wrapped action defines no `<Cancelation>` — a notify period does not apply to those cases, so no numeric value is meaningful. See [Cancelation behavior](#cancelation-behavior). |
 
 **Additionally available in `onWrapEnvEnter` and `onWrapEnvExit`:**
 
@@ -432,12 +439,93 @@ container) MUST remain available until every `onWrapEnvExit` returns.
 ### Cancelation behavior
 
 The wrap hook's own `<Cancelation>` governs how the session runtime cancels
-the wrap script. The wrapped action's own cancelation method is surfaced to
-the wrap script via the `WrappedAction.Cancelation.Mode` template variable,
-so the wrap script MAY honor the inner action's cancelation semantics when it
-propagates the termination signal (for example, allowing a graceful
-notification period before terminating when the wrapped action requested
-`NOTIFY_THEN_TERMINATE`).
+the wrap script. The wrapped action's own cancelation semantics are surfaced
+to the wrap script via two template variables:
+
+- `WrappedAction.Cancelation.Mode` — the wrapped action's cancelation method
+  (`TERMINATE` or `NOTIFY_THEN_TERMINATE`), or `null` if the wrapped action
+  defines no `<Cancelation>`. Note this differs from the runtime's default
+  cancelation semantics: an action with no `<Cancelation>` is canceled as if
+  by `<CancelationMethodTerminate>`, but the variable carries `null` — the
+  "not declared" value for optional data — so wrap scripts can distinguish
+  "author explicitly asked for `TERMINATE`" from "author declared nothing".
+  Interpolated into a format string, `null` renders as the empty string;
+  scripts can apply EXPR's null-coalescing `or` to substitute a fallback
+  (for example `{{ WrappedAction.Cancelation.Mode or 'TERMINATE' }}`).
+- `WrappedAction.Cancelation.NotifyPeriodInSeconds` — the wrapped action's
+  effective grace period between the notify and terminate signals. When the
+  wrapped action's mode is `NOTIFY_THEN_TERMINATE` and it omits
+  `notifyPeriodInSeconds`, the runtime supplies the schema default for the
+  wrapped action's position (120 for a task's `onRun`, 30 otherwise), so the
+  wrap script always sees the value the runtime would have enforced in the
+  unwrapped case. The variable is `null` when the mode is `TERMINATE` or
+  when the wrapped action defines no `<Cancelation>` — a notify period is
+  not meaningful in those cases, and typing it as `int?` avoids conflating
+  "no notify period applies" with a zero-length notify period.
+
+Together these let the wrap script faithfully reproduce the inner action's
+cancelation semantics when it propagates the termination signal: honoring a
+graceful notification period when the wrapped action requested
+`NOTIFY_THEN_TERMINATE` (for example,
+`docker container stop --timeout {{WrappedAction.Cancelation.NotifyPeriodInSeconds}}`),
+or terminating immediately when it requested `TERMINATE`.
+
+Because the variable is `int?`, a `null` value interpolated into a format
+string renders as the empty string — the example above would produce a
+malformed `--timeout` flag if evaluated outside a mode check. Wrap scripts
+that reference the variable unconditionally should either branch on
+`WrappedAction.Cancelation.Mode` first, or apply EXPR's null-coalescing
+`or` to supply a fallback:
+`docker container stop --timeout {{ WrappedAction.Cancelation.NotifyPeriodInSeconds or 30 }}`.
+
+Beyond referencing the variables inside script text, a wrap hook can adopt
+the wrapped action's cancelation semantics as its *own* `<Cancelation>` by
+forwarding both fields as whole-field expressions (requires the
+FEATURE_BUNDLE_1 extension, which gates the format-string `mode` form —
+see Template Schemas §5.3):
+
+```yaml
+onWrapTaskRun:
+  command: echo
+  args: ["{{WrappedAction.Command}}"]
+  timeout: "{{WrappedAction.Timeout}}"
+  cancelation:
+    mode: "{{WrappedAction.Cancelation.Mode}}"
+    notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+```
+
+Whole-field expression evaluation (RFC 0005 "Expression Evaluation Types")
+forwards each variable's type and null-ness into the field, so this
+round-trip MUST work for every state of the wrapped action:
+
+| Wrapped action declares      | `mode:` resolves to        | `notifyPeriodInSeconds:` resolves to | Effective wrap-hook cancelation           |
+|------------------------------|----------------------------|--------------------------------------|-------------------------------------------|
+| `NOTIFY_THEN_TERMINATE`, period *P* (or schema default) | `"NOTIFY_THEN_TERMINATE"` | *P*                    | `NOTIFY_THEN_TERMINATE` with period *P*   |
+| `TERMINATE`                  | `"TERMINATE"`              | `null` → field dropped               | `TERMINATE`                               |
+| no `<Cancelation>`           | `null` → whole object dropped | `null`                            | undeclared (runtime default: terminate)   |
+
+`timeout:` forwards the same way: `WrappedAction.Timeout` is `int?`, so a
+declared timeout forwards verbatim and a `null` result (the wrapped action
+specified no timeout) drops the field, leaving the hook position's schema
+default in effect (see [Timeout behavior](#timeout-behavior)).
+
+A `null` `mode` drops the entire `cancelation` object — `mode` is the
+object's required discriminator, so an "omitted" mode cannot leave a
+partial object behind; the wrap action behaves exactly as if its author
+had declared no `<Cancelation>`. The runtime resolves these expressions
+when it prepares to run the wrap action and MUST fail the action if
+`mode` resolves to anything other than the two method names or `null`.
+
+These two variables surface every field of today's `<CancelationMethod>`
+schema. A structured alternative — forwarding the whole `<Cancelation>`
+object under a single variable — was considered and rejected for ergonomics:
+it would introduce another level of depth in the `WrappedAction.Cancelation`
+chain without carrying more information, and scalar variables compose
+directly with `repr_sh()`/`repr_py()` and EXPR arithmetic in wrap scripts.
+If a future specification adds fields to `<CancelationMethod>`, they surface
+as additional scalars under `WrappedAction.Cancelation.*` using the field's
+PascalCased name, per
+[Forwarding `<Action>` fields, current and future](#forwarding-action-fields-current-and-future).
 
 When the wrap script receives a termination signal (SIGTERM on POSIX,
 platform-equivalent on Windows), it MUST cause the wrapped process to
@@ -468,13 +556,20 @@ runtime where the runtime exposes a timeout mechanism (e.g.,
 enforce it in-script (`timeout {{WrappedAction.Timeout}}s ...`) when the
 runtime exposes none.
 
-When the wrapped action specified no timeout, `WrappedAction.Timeout`
-evaluates to `0`; wrap scripts MUST treat `0` as "no timeout" and omit
-the underlying runtime's timeout flag in that case (for example, omit
-`--timeout` from `docker container stop` rather than passing
-`--timeout 0`, which Docker interprets as "kill immediately").
-The sentinel `0` was chosen because the OpenJD `<posinteger>` schema cannot
-represent absent values.
+When the wrapped action specified no timeout, `WrappedAction.Timeout` is
+`null` — following the EXPR semantics for optional data, as with the
+`WrappedAction.Cancelation.*` variables. Interpolated into a format string,
+`null` renders as the empty string, so wrap scripts that reference the
+variable unconditionally MUST either branch on it first or apply EXPR's
+null-coalescing `or` to supply a fallback; and they MUST omit the
+underlying runtime's timeout flag when the value is `null` (for example,
+omit `--timeout` from `docker container stop` rather than passing
+`--timeout 0`, which Docker interprets as "kill immediately"). Typing the
+variable `int?` rather than using a `0` sentinel lets whole-field
+expression forwarding (`timeout: "{{WrappedAction.Timeout}}"`) work in
+every case: a declared timeout forwards verbatim, and a `null` result
+drops the field so the hook position's schema default applies — a `0`
+sentinel would be out of range for the `<posinteger>` field.
 
 Templates that omit `timeout` on a wrap hook inherit OpenJD's default for
 that hook position. The session runtime enforces the hook timeout by

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -1510,7 +1510,8 @@ The format string scopes available to format strings within an Environment are:
    entity.
 4. Names bound by `let` in the enclosing `<EnvironmentScript>`. Available with the `EXPR` extension.
 5. `WrappedAction.*` — Available within `onWrapEnvEnter`, `onWrapTaskRun`, and `onWrapEnvExit` only. Carries
-   the wrapped `<Action>`'s fields. Available with the `WRAP_ACTIONS` extension. See [RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
+   the wrapped `<Action>`'s fields. Available with the `WRAP_ACTIONS` extension.
+   See [Wrap hook template variables](#431-wrap-hook-template-variables) for the available fields.
 6. `WrappedEnv.Name` — Available within `onWrapEnvEnter` and `onWrapEnvExit` only. The name of the inner
    environment whose action is being wrapped. Available with the `WRAP_ACTIONS` extension.
 7. `WrappedStep.Name` — Available within `onWrapTaskRun` only. The name of the step whose task is being
@@ -1576,17 +1577,11 @@ onExit: <Action> # optional
 1. *onEnter* — The action run when the environment is being entered on a host.
 2. *onWrapEnvEnter* — When provided, runs instead of the `onEnter` action of every *inner* environment that
    enters the session while this environment is active. Available only when using the `WRAP_ACTIONS`
-   extension. See [RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
+   extension.
 3. *onWrapTaskRun* — When provided, runs instead of the task's `onRun` action for every task that runs
-   while this environment is active. Available only when using the `WRAP_ACTIONS` extension. See
-   [RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
+   while this environment is active. Available only when using the `WRAP_ACTIONS` extension.
 4. *onWrapEnvExit* — When provided, runs instead of the `onExit` action of every *inner* environment that
-   exits while this environment is active. Available only when using the `WRAP_ACTIONS` extension. See
-   [RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
-
-Each wrap hook receives the wrapped `<Action>`'s fields via the `WrappedAction.*` template variables.
-An environment that defines any wrap hook must define all three. See
-[RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
+   exits while this environment is active. Available only when using the `WRAP_ACTIONS` extension.
 5. *onExit* — The action run when the environment is being exited on a host.
 
    > **NOTE:** When *onExit* action does not define a *timeout* the action will default to 300
@@ -1606,6 +1601,50 @@ An environment that defines any wrap hook must define all three. See
 >    Schedulers must reject templates that list `WRAP_ACTIONS` without also listing `EXPR`.
 > 4. The wrapping environment's own `onEnter` and `onExit` are never wrapped; they always run
 >    normally.
+
+#### 4.3.1. Wrap hook template variables
+
+Each wrap hook receives the wrapped `<Action>`'s fields as read-only template variables supplied by the
+runtime. The variables have identical names and semantics across all three hooks, so helper scripts can
+be reused unchanged.
+
+**Available in `onWrapEnvEnter`, `onWrapTaskRun`, and `onWrapEnvExit`:**
+
+| Variable                          | Type           | Description |
+|-----------------------------------|----------------|-------------|
+| `WrappedAction.Command`           | `string`       | The `command` from the wrapped action. |
+| `WrappedAction.Args`              | `list[string]` | The `args` from the wrapped action. |
+| `WrappedAction.Environment`       | `list[string]` | Environment variables defined by `openjd_env` earlier in the session, as `["KEY=value", ...]`. |
+| `WrappedAction.Timeout`           | `int?`         | The timeout in seconds specified on the wrapped action. `null` when the wrapped action specifies no timeout. See the *timeout* defaults table in [&lt;Action&gt;](#5-action). |
+| `WrappedAction.Cancelation.Mode`  | `string?`      | The cancelation method of the wrapped action (`TERMINATE` or `NOTIFY_THEN_TERMINATE`). `null` when the wrapped action defines no [&lt;CancelationMethod&gt;](#53-cancelationmethod). |
+| `WrappedAction.Cancelation.NotifyPeriodInSeconds` | `int?` | The effective `notifyPeriodInSeconds` of the wrapped action when its cancelation mode is `NOTIFY_THEN_TERMINATE`, with the [&lt;CancelationMethodNotifyThenTerminate&gt;](#532-cancelationmethodnotifythenterminate) defaults applied when the wrapped action omits the field. `null` when the mode is `TERMINATE` or the wrapped action defines no `<Cancelation>`. |
+
+**Additionally available in `onWrapEnvEnter` and `onWrapEnvExit`:**
+
+| Variable          | Type     | Description |
+|-------------------|----------|-------------|
+| `WrappedEnv.Name` | `string` | The `name` of the inner environment whose action is being wrapped. |
+
+**Additionally available in `onWrapTaskRun`:**
+
+| Variable           | Type     | Description |
+|--------------------|----------|-------------|
+| `WrappedStep.Name` | `string` | The `name` of the step whose task is being wrapped. |
+
+`WrappedAction.Environment` carries only `openjd_env`-defined variables from the current session, including
+variables emitted by earlier actions that themselves ran via a wrap hook. Host-inherited variables (`HOME`,
+`PATH`, `OPENJD_*`, etc.) and host filesystem paths referenced in `WrappedAction.Command` or
+`WrappedAction.Args` (for example, `{{Env.File.X}}` resolves to a host path) are not surfaced; the wrapping
+environment is responsible for forwarding or path-mapping them into the wrapped execution context.
+
+The `WrappedAction.*` namespace is the single, standardized surface for every field of the wrapped
+`<Action>`. When a future specification adds a field to `<Action>`, it must surface under the same
+namespace using the field's PascalCased name (e.g., `WrappedAction.LogMessageTimeout`). New fields gated
+by an `@extension` activate under this namespace exactly when that extension is active in the template.
+Wrap scripts may reference any field they recognize and must tolerate fields they do not.
+
+The wrap hooks and these template variables were introduced in
+[RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
 
 ### 4.4. `<EnvironmentVariables>`
 
@@ -1657,6 +1696,11 @@ positive integer value in base-10, and:
 3. *timeout* — The positive number of seconds that the command is given to successfully run to completion. A command that
    does not return before the timeout is canceled and is treated as a failed
    run. Can only be a `<posintstring>` when using the extension `FEATURE_BUNDLE_1`.
+   When the value is a single whole-field interpolation expression (`"{{ ... }}"` with no
+   surrounding text), its target type is `int?` per the
+   [expression evaluation type](2026-02-Expression-Language#expression-evaluation-types) rules:
+   a `null` result is treated as if the field were not provided (the defaults below apply), and a
+   non-null result MUST be a positive integer.
 
    The default timeout, if not provided, depends on the action:
 
@@ -1676,8 +1720,10 @@ positive integer value in base-10, and:
    <sup>2</sup> Available with the `WRAP_ACTIONS` extension. The wrap hook's `timeout` field bounds
    the wrap script on the host (infrastructure-side); the `WrappedAction.Timeout` template variable
    carries the wrapped action's timeout (workload-side). When the wrapped action specified no
-   timeout, the variable evaluates to `0`.
-   See [RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
+   timeout, the variable is `null` (it is typed `int?`). Wrap scripts must propagate the wrapped
+   timeout to the underlying execution runtime where the runtime exposes a timeout mechanism, and
+   should enforce it in-script when the runtime exposes none. Wrap scripts must treat `null` as
+   "no timeout" and omit the underlying runtime's timeout flag in that case.
 
 4. *cancelation* — If defined, provides details regarding how this action should be canceled. If not provided, then it is
    treated as though provided with `<CancelationMethodTerminate>`.
@@ -1712,6 +1758,42 @@ The cancellation method defines the process by which an action is canceled.
 ```bnf
 <CancelationMethod> ::= <CancelationMethodTerminate> | <CancelationMethodNotifyThenTerminate>
 ```
+
+The *mode* value selects between the two forms. When using the `FEATURE_BUNDLE_1` extension, *mode*
+may instead be a [Format String](#73-format-strings):
+
+```yaml
+mode: "TERMINATE" | "NOTIFY_THEN_TERMINATE"
+mode: "TERMINATE" | "NOTIFY_THEN_TERMINATE" | <fmtstring> # @fmtstring @extension FEATURE_BUNDLE_1
+notifyPeriodInSeconds: <posinteger> | <posintstring> # @optional @fmtstring @extension FEATURE_BUNDLE_1
+```
+
+When *mode* is a format string, the runtime resolves it when it prepares to run the action:
+
+1. If the resolved value is `"TERMINATE"` or `"NOTIFY_THEN_TERMINATE"`, the object is interpreted as
+   the corresponding `<CancelationMethod>` form, and MUST then validate against that form's schema.
+   A *notifyPeriodInSeconds* whole-field expression that resolves to `null` is treated as if the
+   field were not provided (the schema defaults apply).
+2. When the value is a single whole-field interpolation expression (`"{{ ... }}"` with no
+   surrounding text), its target type is `string?` per the
+   [expression evaluation type](2026-02-Expression-Language#expression-evaluation-types) rules: a
+   `null` result causes the entire `<CancelationMethod>` object to be treated as if it were not
+   provided — the action is canceled as if by `<CancelationMethodTerminate>`, exactly as when the
+   template author declares no *cancelation*.
+3. Any other resolved value is an error; the runtime MUST fail the action.
+
+The primary use of a format-string *mode* is RFC 0008 wrap hooks forwarding the wrapped action's
+cancelation verbatim (see [wrap hook template variables](#431-wrap-hook-template-variables)):
+
+```yaml
+cancelation:
+  mode: "{{WrappedAction.Cancelation.Mode}}"
+  notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+```
+
+This forwards every case faithfully: a declared mode is reproduced verbatim; a `null` mode (the
+wrapped action declared no `<Cancelation>`) drops the whole *cancelation* object; and a `null`
+notify period (mode is `TERMINATE` or undeclared) drops that field so the schema default applies.
 
 #### 5.3.1. `<CancelationMethodTerminate>`
 
@@ -1753,6 +1835,11 @@ positive integer value in base-10, and:
    2. Defaults:
       * 120 if the Action is the "onRun" action of a `<StepActions>` object.
       * 30 otherwise.
+   3. When the value is a single whole-field interpolation expression (`"{{ ... }}"` with no
+      surrounding text), its target type is `int?` per the
+      [expression evaluation type](2026-02-Expression-Language#expression-evaluation-types) rules:
+      a `null` result is treated as if the field were not provided (the defaults above apply), and
+      a non-null result MUST be a positive integer within the maximum.
 
 The signals sent to the command are:
 
@@ -2132,7 +2219,11 @@ positive integer value in base-10, and:
    default expectation should be that OpenJobDescription sessions are able to
    end and cleanup within a bound duration of time.
 
-   <sup>2</sup> Available with the `WRAP_ACTIONS` extension. See [RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
+   <sup>2</sup> Available with the `WRAP_ACTIONS` extension. The wrap hook's `timeout` field bounds
+   the wrap script on the host (infrastructure-side); the `WrappedAction.Timeout` template variable
+   carries the wrapped action's timeout (workload-side). When the wrapped action specified no
+   timeout, the variable is `null` (it is typed `int?`). See the *timeout* description in
+   [&lt;Action&gt;](#5-action).
 
 5. *cancelation* — If defined, provides details regarding how this action should
    be canceled. If not provided, then it is treated as though provided with `<CancelationMethodTerminate>`.

--- a/wiki/How-Jobs-Are-Run.md
+++ b/wiki/How-Jobs-Are-Run.md
@@ -32,14 +32,35 @@ values identical except for the chunked Task parameter. It takes values from an 
 like "1-3" or 1-3,5,7" depending on whether the chunks are constrained to be contiguous or not.
 
 If exactly one Environment in the session stack defines the wrap hooks (`onWrapEnvEnter`, `onWrapTaskRun`,
-`onWrapEnvExit`, part of the WRAP_ACTIONS extension), the lifecycle actions of inner Environments and tasks
+`onWrapEnvExit`, part of the WRAP_ACTIONS extension introduced in
+[RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md)),
+the lifecycle actions of inner Environments and tasks
 are intercepted: an inner Environment's `onEnter` is replaced by the wrapping Environment's
 `onWrapEnvEnter`, a task's `onRun` is replaced by the wrapping Environment's `onWrapTaskRun`, and an inner
 Environment's `onExit` is replaced by the wrapping Environment's `onWrapEnvExit`. The wrapping Environment's
 own `onEnter` and `onExit` are never wrapped; they always run normally. If more than one Environment
 in the session stack defines any wrap hook, the session is invalid and the scheduler must reject it
-before entering any Environment. If an Environment defines any wrap hook, it must define all three. See
-[RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
+before entering any Environment. If an Environment defines any wrap hook, it must define all three.
+
+A wrap hook is treated as the action it replaces. A failed `onWrapEnvEnter` is an inner `onEnter`
+failure, a failed `onWrapTaskRun` is a task `onRun` failure, and a failed `onWrapEnvExit` is an inner
+`onExit` failure; the **Session** handles each failure exactly as it would in the unwrapped case. Wrap
+scripts must propagate the wrapped process's exit status as their own.
+
+Wrap hooks extend the **Session**'s cleanup guarantee symmetrically: if `onWrapEnvEnter` starts for an
+inner Environment, that inner Environment's `onWrapEnvExit` must run, and the wrapping Environment's own
+`onExit` must run on top of that. Resources allocated by the wrapping Environment's `onEnter` (for
+example, a container) must remain available until every `onWrapEnvExit` returns.
+
+The wrap hook's own cancelation method governs how the wrap script is canceled. The wrapped action's
+cancelation semantics are surfaced to the wrap script via the `WrappedAction.Cancelation.Mode` and
+`WrappedAction.Cancelation.NotifyPeriodInSeconds` template variables, so the wrap script may honor the
+inner action's cancelation semantics when it propagates the termination signal — for example, allowing
+a graceful notification period equal to `WrappedAction.Cancelation.NotifyPeriodInSeconds` before
+terminating when the wrapped action requested `NOTIFY_THEN_TERMINATE`. When the wrap script receives a
+termination signal, it must cause the wrapped process to receive a termination signal within the
+cancelation grace period; after the grace period the wrap script receives SIGKILL, which cannot be
+trapped.
 
 When the EXPR extension is used, format strings evaluated on the Worker Host support the full
 [expression language](2026-02-Expression-Language) including arithmetic, conditionals, function calls,
@@ -123,9 +144,11 @@ messages to convey information about the **Action** to the render management sys
 
 When the WRAP_ACTIONS extension is in use, schedulers must scan the stdout of the wrap script (`onWrapEnvEnter`,
 `onWrapTaskRun`, or `onWrapEnvExit`) for these macros, not the stdout of the wrapped process. Wrap scripts must
-forward the wrapped process's stdout and stderr verbatim, which causes macros emitted by the wrapped process
-to be recognized identically to macros emitted by the wrap script itself. See
-[RFC 0008](https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/rfcs/0008-environment-wrap-actions.md).
+forward the wrapped process's stdout and stderr verbatim — without buffering, filtering, or transformation —
+which causes macros emitted by the wrapped process to be recognized identically to macros emitted by the wrap
+script itself. A wrap script may also emit these macros directly. The `WrappedAction.Environment` template
+variable includes every `openjd_env`-defined variable emitted by any earlier **Action** in the same
+**Session**, regardless of whether that **Action** ran normally or via a wrap hook.
 
 ## Path Mapping
 


### PR DESCRIPTION
## Summary

Follow-up to #130, addressing the review comments that were deferred at merge time. RFC 0008 (Environment Wrap Actions) was approved with: *"I see some references from the schema to the RFC for things that should live in the schema. Let's merge and then do a follow-up where we fix that."*

This PR resolves that condition plus the remaining open review threads.

## Review comments addressed

### 1. Schema doc delegates normative content to the RFC (@mwiebe, approval condition + inline on `2023-09-Template-Schemas.md` L1507)

> "This spec doc is the authoritative reference, so we should copy that here instead of referencing the RFC."

**Addressed by** copying the normative content into the spec docs and keeping RFC links for attribution only:

- `2023-09-Template-Schemas.md`: new section **4.3.1 Wrap hook template variables** with the full `WrappedAction.*` / `WrappedEnv.Name` / `WrappedStep.Name` tables, the host-env/path forwarding rule, the `openjd_env` accumulation rule, and the future-fields PascalCase namespace rule. The `<Action>` and `<SimpleAction>` timeout footnotes now carry the wrap-script timeout propagation and zero-sentinel rules instead of linking out.
- `How-Jobs-Are-Run.md`: copied in wrap failure semantics (a wrap hook is treated as the action it replaces; exit-status propagation), the symmetric cleanup guarantee, cancelation signal propagation, and the stdout forwarding / macro-scanning rules.

### 2. Forwarding the full Cancelation object (@mwiebe, inline on RFC L294)

> "As a next step we should look at how a template could forward the full Cancelation object instead of just its Mode."

**Proposal included in this PR:** add `WrappedAction.Cancelation.NotifyPeriodInSeconds` (`int?`) alongside the existing `WrappedAction.Cancelation.Mode`:

- When the wrapped action's mode is `NOTIFY_THEN_TERMINATE`, the runtime supplies the *effective* grace period, applying the schema defaults (120 for a task's `onRun`, 30 otherwise) when the field is omitted — so the wrap script always sees the value the runtime would have enforced in the unwrapped case.
- `null` when the mode is `TERMINATE` or no `<Cancelation>` is defined — a notify period does not apply in those cases, and typing the variable as `int?` avoids conflating "not applicable" with a zero-length notify period. *(Updated per review feedback — earlier revisions used a `0` sentinel matching the `WrappedAction.Timeout` convention.)* Because `null` renders as the empty string in a format string, the RFC now documents the guard needed for unconditional references: branch on `WrappedAction.Cancelation.Mode` first, or use EXPR null-coalescing, e.g. `docker container stop --timeout {{ WrappedAction.Cancelation.NotifyPeriodInSeconds or 30 }}`.

**Alternative considered:** forwarding the whole `<Cancelation>` as a structured object. Rejected for ergonomics — it adds another level of depth to the `WrappedAction.Cancelation` chain without carrying more information, and scalar variables compose directly with `repr_sh()`/`repr_py()` and EXPR arithmetic in wrap scripts. Future `<CancelationMethod>` fields surface as additional PascalCased scalars under `WrappedAction.Cancelation.*`, per the RFC's existing future-fields rule. These two variables cover every field of today's `<CancelationMethod>` schema.

### 3. Basic Example uses invalid format-string timeouts (automated review, unresolved)

> `timeout: "{{WrappedAction.Timeout}}"` conflicts with the schema: format-string timeouts require `FEATURE_BUNDLE_1` (not declared in the example), and `WrappedAction.Timeout` evaluates to `0` when the wrapped action has no timeout, which is out of range for `<posinteger>`.

**Addressed by** removing the `timeout:` lines from the example's wrap hooks (they now inherit the defaults for their hook positions) and adding a paragraph after the example explaining why, pointing at the Timeout behavior section for how the wrapped timeout is enforced from inside the wrap script instead.

A new invalid fixture guards the mistake: `4.2--wrap-fmtstring-timeout-no-feature-bundle.invalid.yaml` asserts a format-string `timeout` on a wrap hook is rejected without `FEATURE_BUNDLE_1`.

### 4. `wrap-partial-hooks-rejected` could fail for the wrong reason (automated review, unresolved)

> The env declares only `WRAP_ACTIONS` and omits `EXPR`, so a validator may reject it on the missing-`EXPR` rule before ever evaluating the all-or-nothing rule the test is meant to exercise.

**Addressed by** adding `EXPR` to the environment's extensions so the partial hook set is the only remaining defect.

### 5. README timeout-sentinel bullet mislists a fixture (automated review, unresolved)

> `wrap-timeout-injected-python` sets `timeout: 300` and asserts `TIMEOUT=300` — it does not exercise the `0`-when-unset case.

**Addressed by** moving it under the "Variable injection" bullet; the zero-sentinel bullet now references only `wrap-task-action-timeout-zero-when-unset`.

## Conformance coverage for the new variables

Nine new job fixtures pin the `WrappedAction.Cancelation.*` semantics (see the WRAP_ACTIONS conformance README for the full inventory):

- **Mode injection**: `TERMINATE`, `NOTIFY_THEN_TERMINATE`, and the empty string when the wrapped action defines no `<Cancelation>` (three fixtures — the empty case is distinct from an explicit `TERMINATE` so implementations cannot conflate "author declared TERMINATE" with "author declared nothing").
- **Notify-period injection**: explicit value forwarded verbatim; schema-default forwarding for all three wrapped-action positions (120 for a task's `onRun`; 30 for an env `onEnter` and an env `onExit`); and the `null` sentinel for both not-applicable cases (`TERMINATE` mode, and no `<Cancelation>` declared).

## Testing

- YAML fixtures validated for syntax; conformance CI on this PR exercises the new/updated tests against both the Python and Rust CLIs.
- The new `4.2--wrap-fmtstring-timeout-no-feature-bundle.invalid.yaml` fixture doubles as a check that both validators reject format-string wrap-hook timeouts without `FEATURE_BUNDLE_1`.
- **Rust (openjd-rs)**: the `Cancelation.*` seed-path and validator changes are implemented (leongdl/openjd-rs `1fd8ea5`); all 9 new fixtures pass, and the full local conformance run is 1138 passed / 0 failed.
- **Python (openjd-sessions-for-python)**: implements the PR #130 variables (`WrappedAction.Command/Args/Environment/Timeout`) but does not yet seed `WrappedAction.Cancelation.*`. The matching port (session seed path + validator symbol registration) is needed before conformance CI can go green on both CLIs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.