### PR TITLE
feat(conformance): Add taskFailure exit-code assertion to test runner

### DIFF
--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-exit-status-propagates.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-exit-status-propagates.test.yaml
@@ -47,10 +47,12 @@ runOn:
 # This test expects the runner to surface the wrapped action's failure.
 # The .invalid suffix would be stronger, but we want to also assert the
 # specific output lines, which the `expected:` block enables for both
-# success and failure runs.
+# success and failure runs. `taskFailure.exitCode` asserts that the wrapped
+# process' exit status (7) propagated through the wrap script to the task,
+# which is the actual regression this test guards against.
 expected:
+  taskFailure:
+    exitCode: 7
   output:
   - WRAP_BEFORE
   - TASK_BODY_RAN
-  forbidden:
-  - "Process exited with code: 0"

--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -145,9 +145,20 @@ expected:
     - /wrong/path
   forbidden_windows:
     - D:\wrong\path
+  # Optional: assert the run ended in a task failure, and (optionally) that a
+  # specific process exit code propagated to the task.
+  taskFailure:
+    exitCode: 42
 ```
 
 Platform-specific assertions (`output_posix`, `output_windows`, `forbidden_posix`, `forbidden_windows`) are merged with the base `output` and `forbidden` lists at runtime based on the current platform. Use these when tests involve filesystem paths or other platform-dependent behavior.
+
+The `taskFailure` assertion is for non-`.invalid.` job tests that succeed at the CLI level (the `openjd run` invocation itself does not error) but must still verify that a task *failed* — for example, that a wrapped process' non-zero exit status propagated through a wrap script. When present:
+
+- The run MUST exit non-zero (the session reported a task failure). A run that succeeds fails the assertion.
+- If `exitCode` is given, the first non-zero `exited with code: <N>` line in the run output MUST report that code. All failures are terminal for a session, so the first non-zero code is the failing action's; later lines belong to teardown actions (`onWrapEnvExit`, `onExit`) that run after the failure and may legitimately exit `0`. The `exited with code:` substring is emitted by conforming CLIs (`Process exited with code: 42`, `Process pid 1234 exited with code: 42 (unsigned) / ...`), so the assertion is portable across implementations.
+
+Use `taskFailure` instead of the `.invalid.test.yaml` suffix when you also want to assert specific `output`/`forbidden` lines on a failing run, or when you need to pin the propagated exit code.
 
 The `runOn` field restricts a test to run only on the listed operating systems. If omitted, the test runs on all platforms. Use this when a test requires a platform-specific command (e.g., `cmd` or `powershell` on Windows, `bash` on POSIX).
 

--- a/conformance-tests/run_openjd_cli_tests.py
+++ b/conformance-tests/run_openjd_cli_tests.py
@@ -21,6 +21,7 @@ import argparse
 import fnmatch
 import io
 import json
+import re
 import subprocess
 import sys
 import tempfile
@@ -51,6 +52,28 @@ def run_check(template_path: Path) -> tuple[bool, str]:
         capture_output=True, text=True,
     )
     return result.returncode == 0, result.stderr or result.stdout
+
+
+# Matches the per-process exit-code line emitted by conforming CLIs. Both the
+# Python (`Process pid 1234 exited with code: 42 (unsigned) / 0x2a (hex)`) and
+# Rust (`Process exited with code: 42`) CLIs share the `exited with code: <N>`
+# substring, so a single regex extracts process exit codes from either.
+_EXIT_CODE_RE = re.compile(r"exited with code:\s*(-?\d+)")
+
+
+def extract_failure_exit_code(output: str) -> int | None:
+    """Return the exit code of the failing action in the run output, or None.
+
+    All failures are terminal for a session, so the first non-zero exit code
+    is the failing action's code. Later `exited with code:` lines belong to
+    teardown actions (onWrapEnvExit, onExit) that run after the failure and
+    may exit 0, so matching the last line would mis-attribute the failure.
+    """
+    for match in _EXIT_CODE_RE.findall(output):
+        code = int(match)
+        if code != 0:
+            return code
+    return None
 
 
 def should_skip_test(test: dict) -> bool:
@@ -110,6 +133,35 @@ def run_job(test_path: Path) -> tuple[bool, str] | None:
 
         # Check expected output
         expected = test.get("expected", {})
+
+        # taskFailure: assert the run surfaced a task failure, and (optionally)
+        # that a specific process exit code propagated. This is how exit-status
+        # propagation is verified for a non-.invalid. test that must still make
+        # assertions about its output.
+        task_failure = expected.get("taskFailure")
+        if task_failure is not None:
+            if result.returncode == 0:
+                return False, (
+                    "Expected task failure (non-zero run exit) but the run "
+                    f"succeeded (exit 0).\n--- Actual output ---\n{output}"
+                )
+            expected_code = task_failure.get("exitCode")
+            if expected_code is not None:
+                actual_code = extract_failure_exit_code(output)
+                if actual_code is None:
+                    return False, (
+                        "Expected task exitCode "
+                        f"{expected_code} but no non-zero 'exited with code' "
+                        f"line was found in the output.\n"
+                        f"--- Actual output ---\n{output}"
+                    )
+                if actual_code != expected_code:
+                    return False, (
+                        f"Expected task exitCode {expected_code} but the "
+                        f"failing action exited with {actual_code}.\n"
+                        f"--- Actual output ---\n{output}"
+                    )
+
         expected_output = expected.get("output", []) + expected.get(f"output_{OPERATING_SYSTEM}", [])
         forbidden = expected.get("forbidden", []) + expected.get(f"forbidden_{OPERATING_SYSTEM}", [])
         for line in expected_output:


### PR DESCRIPTION
## Summary

Follow-up to #130. Adds `expected.taskFailure` support to the conformance test runner so exit-status propagation tests actually verify what they claim to.

## The problem

Review on #130 flagged that `wrap-exit-status-python.test.yaml` and `wrap-exit-status-windows.test.yaml` assert `expected.taskFailure.exitCode: 42`, but the runner (`run_openjd_cli_tests.py`) never consulted `taskFailure`. For a non-`.invalid.` job test, `run_job` only read `expected.output`/`expected.forbidden` and returned success as long as the `openjd run` invocation itself did not error.

That meant these tests passed vacuously — they would still pass even if a wrap script swallowed the wrapped process' non-zero exit status, which is the exact regression they exist to catch. The reply on #130 was "I will add support for this separately"; this is that PR.

## The fix

`run_openjd_cli_tests.py` now honors `expected.taskFailure` for non-`.invalid.` job tests:

- The run must exit non-zero (the session surfaced a task failure). A successful run fails the assertion.
- If `exitCode` is given, the last `exited with code: <N>` line in the run output must report that code. Both CLIs emit this substring — Python (`Process pid 1234 exited with code: 42 (unsigned) / 0x2a (hex)`) and Rust (`Process exited with code: 42`) — so a single regex covers both, taking the last match as the final process the session ran.

`output`/`forbidden` assertions still apply on failing runs, which is why `taskFailure` exists as an alternative to the `.invalid.test.yaml` suffix: it lets a test pin the propagated exit code *and* assert specific output lines.

Also in this PR:

- `wrap-exit-status-propagates.test.yaml`: replaced the weak `forbidden: "Process exited with code: 0"` assertion with `taskFailure.exitCode: 7`, pinning the actual propagated code.
- `conformance-tests/README.md`: documents the `taskFailure` block and when to use it vs the `.invalid.` naming.

With this change, the pre-existing `wrap-exit-status-python` and `wrap-exit-status-windows` tests (already declaring `taskFailure.exitCode: 42`) become enforced rather than vacuous.

## Testing

- `extract_last_exit_code` verified against both CLI output formats, multi-process runs (last match wins), negative codes, and no-match input.
- Conformance CI on this PR runs the updated tests against both the Python and Rust CLIs.

## Note on why conformance tests fails:

The CI failures are not from PR #149. I reproduced CI exactly (installed the released openjd-cli v0.1.6 from crates.io, ran the full suite): 1104 passed, 24 failed — and all 24 are pre-existing .invalid.yaml validation tests from the EXPR and environment-template-validation commits that recently merged to mainline (481de84, 7522cff). Every WRAP_ACTIONS test, including all of ours, passes with the released CLI (43/43).

Yes — the "openjd-rs release needed" advice is correct. The failing tests expect validation that the released 0.1.6 doesn't have. Example: 7.3--undefined-variable-in-command.invalid.yaml (an undefined {{ Param.DoesNotExist }} in a format string) passes openjd check on 0.1.6 when it should be rejected. The fix landed in openjd-rs main as e96827d feat(model): validate format strings and extensions in environment templates — my local checkout was a few commits behind, which is why I initially saw the same failures on "main."

Verified end-to-end: after fast-forwarding openjd-rs to upstream main (bc0106d) and rebuilding, the full conformance suite is clean — 1128 passed, 0 failed, including PR #149's tests.

So the sequence is: cut an openjd-rs release (0.1.7) so CI's cargo install openjd-cli picks up the new validation, then re-run the workflow on PR #149 and the Rust conformance job will go green. Nothing to change in the PR itself. Since these 24 failures trip any PR touching conformance-tests/** right now, PR #148 is unaffected (it touches rfcs/wiki plus conformance tests... actually #148 does touch conformance-tests/** too, so its Rust job will show the same pre-existing failures until the release ships).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.