### PR TITLE
fix(conformance): forward WrappedAction args directly in wrap-exit-status-windows

### DIFF
--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-exit-status-windows.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-exit-status-windows.test.yaml
@@ -1,5 +1,12 @@
 # RFC 0008: Windows variant of exit-status propagation.
-# The wrapped action exits non-zero; the wrap script must propagate it.
+# The wrapped action exits non-zero; the wrap hook must propagate it.
+#
+# The wrap hooks forward the wrapped action's command and args directly
+# (the argv analog of the `exec` idiom from RFC 0008 "Exit status
+# propagation"). A bare "{{ WrappedAction.Args }}" args element is a
+# list[string] and flattens inline (RFC 0005), so each wrapped args element
+# becomes exactly one argument and the wrapped process's exit status becomes
+# the hook's own.
 runOn:
 - windows
 
@@ -24,20 +31,14 @@ environments:
     script:
       actions:
         onWrapEnvEnter:
-          command: cmd
-          args:
-          - "/c"
-          - "{{ repr_cmd(WrappedAction.Command) }} {{ repr_cmd(WrappedAction.Args) }}"
+          command: "{{ WrappedAction.Command }}"
+          args: ["{{ WrappedAction.Args }}"]
         onWrapTaskRun:
-          command: cmd
-          args:
-          - "/c"
-          - "{{ repr_cmd(WrappedAction.Command) }} {{ repr_cmd(WrappedAction.Args) }}"
+          command: "{{ WrappedAction.Command }}"
+          args: ["{{ WrappedAction.Args }}"]
         onWrapEnvExit:
-          command: cmd
-          args:
-          - "/c"
-          - "{{ repr_cmd(WrappedAction.Command) }} {{ repr_cmd(WrappedAction.Args) }}"
+          command: "{{ WrappedAction.Command }}"
+          args: ["{{ WrappedAction.Args }}"]
 
 expected:
   taskFailure:


### PR DESCRIPTION
## Problem

The test's wrap hooks rebuild the wrapped action as a single string inside an
inline args element:

```yaml
onWrapTaskRun:
  command: cmd
  args:
  - "/c"
  - "{{ repr_cmd(WrappedAction.Command) }} {{ repr_cmd(WrappedAction.Args) }}"
```

That misuses `repr_cmd()`. RFC 0006 defines its escaping for cmd-parsed text,
such as the contents of a `.bat` file. An args element is not cmd source text
— it's an argument value. The runtime quotes it as an argument when building
the child's command line (on Windows a child receives one flat string, so the
runtime escapes each args element to keep it a single argument), and cmd.exe
cannot decode that argument-style escaping.

## Fix

Forward the wrapped action's command and args directly — the argv analog
of the `exec` idiom from RFC 0008 "Exit status propagation":

```yaml
onWrapTaskRun:
  command: "{{ WrappedAction.Command }}"
  args: ["{{ WrappedAction.Args }}"]
```

A bare list-valued args element flattens inline (RFC 0005), so each wrapped
args element passes through as exactly one argument, and the test still
verifies exit-status propagation through wrap hooks on Windows — without
embedding cmd source text in args.

## Verification

Verified on Windows against openjd-rs: the rewritten test passes, and the
full `2023-09/WRAP_ACTIONS` suite passes 15/15.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
