### PR TITLE
fix: allow `Task.File.*` in `<StepScript>.let`, matching `Env.File.*` in environments

### DIFF
--- a/conformance-tests/2023-09/EXPR/job_templates/3.6--let-host-context-symbols.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/3.6--let-host-context-symbols.yaml
@@ -21,10 +21,16 @@ steps:
     let:
     - work_dir = Session.WorkingDirectory / 'output'
     - frame_file = Param.OutputDir / string(Task.Param.Frame)
+    - data_file = Task.File.Data
+    embeddedFiles:
+    - name: Data
+      type: TEXT
+      filename: data.txt
+      data: "hello"
     actions:
       onRun:
         command: echo
-        args: ["{{work_dir}}", "{{frame_file}}"]
+        args: ["{{work_dir}}", "{{frame_file}}", "{{data_file}}"]
 
 - name: SimpleActionLet
   parameterSpace:

--- a/conformance-tests/2023-09/EXPR/jobs/7.3--task-file-expr-properties.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/7.3--task-file-expr-properties.test.yaml
@@ -1,0 +1,37 @@
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Greeting
+    type: STRING
+    default: hello
+  steps:
+  - name: Step1
+    script:
+      embeddedFiles:
+      - name: config
+        type: TEXT
+        data: "greeting={{Param.Greeting}}"
+      let:
+      - "cfg = Task.File.config"
+      - "has_parent = len(string(cfg.parent)) > 0"
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            import os
+            path = {{ repr_py(cfg) }}
+            exists = os.path.isfile(path)
+            content = open(path).read() if exists else ''
+            print(f'EXISTS:{exists}')
+            print(f'CONTENT:{content}')
+            print(r'HAS_PARENT:{{ has_parent }}')
+expected:
+  output:
+  - "EXISTS:True"
+  - "CONTENT:greeting=hello"
+  - "HAS_PARENT:true"

--- a/rfcs/0005-expression-language.md
+++ b/rfcs/0005-expression-language.md
@@ -1964,8 +1964,11 @@ steps:
 ##### ScriptTemplate Extension
 
 When `let` appears in a `ScriptTemplate`, bindings are evaluated once per task (or once
-per environment action). The bound names are available in `actions` and can reference
-`Task.Param`:
+per environment action). The bound names are available in `actions` and `embeddedFiles`,
+and can reference `Task.Param.*` as well as the embedded file path symbols of the same
+script (`Task.File.*` in a step script, `Env.File.*` in an environment script) — the
+file path is determined before the bindings are evaluated, even though the file content
+is evaluated separately:
 
 ```yaml
 script:

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -1458,16 +1458,17 @@ and where the bound names are available:
 | Location | Can Reference | Bound Names Available In |
 |----------|---------------|--------------------------|
 | `<StepTemplate>.let` | `Param.*`, `RawParam.*`, `Job.Name`, `Step.Name`, earlier bindings in same `let` | *stepEnvironments*, *hostRequirements*, *parameterSpace*, *script* (including nested `<StepScript>.let` or `<SimpleAction>.let`) |
-| `<StepScript>.let` | `Param.*`, `RawParam.*`, `Task.Param.*`, `Task.RawParam.*`, `Session.*`, `Job.Name`, `Step.Name`, step-level bindings, earlier bindings in same `let` | *actions*, *embeddedFiles* |
+| `<StepScript>.let` | `Param.*`, `RawParam.*`, `Task.Param.*`, `Task.RawParam.*`, `Session.*`, `Task.File.*`, `Job.Name`, `Step.Name`, step-level bindings, earlier bindings in same `let` | *actions*, *embeddedFiles* |
 | `<SimpleAction>.let` | `Param.*`, `RawParam.*`, `Task.Param.*`, `Task.RawParam.*`, `Session.*`, `Job.Name`, `Step.Name`, step-level bindings, earlier bindings in same `let` | *script*, *args* |
 | `<EnvironmentScript>.let` | `Param.*`, `RawParam.*`, `Session.*`, `Env.File.*`, `Job.Name`, earlier bindings in same `let` | *actions*, *embeddedFiles* |
 
 Note: `Task.Param.*` and `Task.RawParam.*` are only available in `<StepScript>` and `<SimpleAction>` contexts because task parameter
 values are not known until task execution time.
 
-Note: `Env.File.*` symbols in `<EnvironmentScript>.let` refer to embedded files defined in the same `<EnvironmentScript>`.
-The file path is determined before evaluation, so `let` bindings can reference the path where the file will be written,
-even though the file content (which may also contain format strings) is evaluated separately.
+Note: `Task.File.*` symbols in `<StepScript>.let` and `Env.File.*` symbols in `<EnvironmentScript>.let` refer to
+embedded files defined in the same script. The file path is determined before evaluation, so `let` bindings can
+reference the path where the file will be written, even though the file content (which may also contain format
+strings) is evaluated separately.
 
 Note: `Job.Name` is concrete at job creation, so it is available in every `let` scope. `Step.Name` is scoped to the
 Step Template (see [7.3.1](#731-value-references)), so it is available in the Step-side `let` scopes but not in


### PR DESCRIPTION
### Background

Templates can define embedded files — small scripts or config
files that the worker writes to disk before running an action. `Env.File.<name>`
and `Task.File.<name>` are the symbols that tell you *where* such a file will
land. With the `EXPR` extension, `let` bindings let you name a computed value
once and reuse it across the script.

The spec's Let Binding Scope Summary (Template Schemas §3.6.2) says an
environment script's `let` bindings may reference `Env.File.*`, because the
file's *path* is decided before the bindings run — only its *content* is
evaluated later. That exact reasoning applies to step scripts and
`Task.File.*` too, but the `<StepScript>.let` row never granted it. While
fixing evaluation ordering in OpenJobDescription/openjd-rs#260 we found that
implementations already accept `Task.File.*` there — the spec table was just
inconsistent between the two contexts.

### The change

Grant `Task.File.*` in the `<StepScript>.let` scope row and
generalize the accompanying note to cover both contexts; state the same grant
explicitly in RFC 0005 (which previously only implied the environment side via
an example); and back it with conformance tests — the §3.6 validation fixture
now actually exercises `Task.File.*` in `let` (its header comment already
claimed to), plus a new runtime test mirroring the existing `Env.File` one.

### Verification

Full `2023-09/EXPR` conformance suite passes (350/350) against
openjd-rs built with #260. A pre-#260 build fails the new runtime test,
confirming it guards the fixed behavior.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
