### PR TITLE
test: Add 13 WRAP_ACTIONS conformance fixtures from the coverage audit

### DIFF
--- a/conformance-tests/2023-09/WRAP_ACTIONS/README.md
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/README.md
@@ -109,8 +109,21 @@ WRAP_ACTIONS/
     ├── wrap-cancelation-roundtrip-terminate.test.yaml
     ├── wrap-cancelation-roundtrip-no-cancelation.test.yaml
     ├── wrap-cancelation-roundtrip-period-only.test.yaml
+    ├── wrap-cancelation-roundtrip-job-environment.test.yaml
     ├── wrap-cancelation-partial-fmtstring-mode.test.yaml
+    │  # Run-time cancelation validation (§5.3: "the runtime MUST fail the action")
+    ├── wrap-cancelation-mode-resolves-invalid-fails.test.yaml
+    ├── wrap-cancelation-terminate-with-period-fails.test.yaml
+    ├── wrap-cancelation-period-over-cap-fails.test.yaml
+    │  # Environment-template scope carried to wrap hooks
+    ├── wrap-env-template-parameters-in-hooks.test.yaml
+    ├── wrap-env-let-bindings-in-hooks.test.yaml
     ├── wrap-openjd-env-from-wrapped-onenter-propagates.test.yaml
+    ├── wrap-openjd-fail-from-wrapped-process.test.yaml
+    ├── wrap-environment-excludes-variables-map.test.yaml
+    │  # Failure semantics & cleanup guarantees
+    ├── wrap-failed-enter-still-runs-wrap-exit.test.yaml
+    ├── wrap-inner-env-without-on-exit-skips-exit-hook.test.yaml
     │  # Exit-status propagation
     ├── wrap-exit-status-propagates.test.yaml
     ├── wrap-exit-status-python.test.yaml
@@ -133,9 +146,18 @@ WRAP_ACTIONS/
     ├── wrap-without-expr-extension.invalid.test.yaml
     ├── wrap-cancelation-fmtstring-mode-no-feature-bundle.invalid.test.yaml
     ├── wrap-multiple-wrap-envs-rejected.invalid.test.yaml
+    ├── wrap-two-wrap-env-templates-rejected.invalid.test.yaml
     ├── wrap-job-and-step-env-rejected.invalid.test.yaml
     ├── wrap-partial-hooks-rejected.invalid.test.yaml
     └── wrap-wrappedaction-outside-wrap-hook-rejected.invalid.test.yaml
+```
+
+Two additional env-template validation fixtures cover the variable scope
+rule beyond action args (`env_templates/`):
+
+```
+    ├── 4--wrappedaction-in-cancelation-outside-hook.invalid.yaml
+    └── 4--wrappedaction-in-embedded-file.invalid.yaml
 ```
 
 Most execution tests use POSIX shell commands (`sh`, `echo`, `printf`) and
@@ -228,9 +250,55 @@ bundles in this directory:
     normal format string behavior — partial interpolation like
     `"{{ ... }}_THEN_TERMINATE"` is valid; the resolved value is checked
     against the two mode names at run time)
+- **Run-time cancelation validation** (Template Schemas §5.3: after a
+  format-string `mode` resolves, "the object MUST then validate against
+  that form's schema" and "Any other resolved value is an error; the
+  runtime MUST fail the action"; §5.3.2 caps the notify period at 600).
+  Constant expressions could be folded and rejected during validation, so
+  each fixture derives its invalid value from `WrappedAction.*` — seeded
+  per-action at host evaluation time, unknowable statically or at job
+  creation — forcing the check to happen where the spec requires it. The
+  wrapped action's script must never run:
+  - `wrap-cancelation-mode-resolves-invalid-fails` (forwarded mode plus a
+    literal suffix resolves to a non-mode string)
+  - `wrap-cancelation-terminate-with-period-fails` (forwarded mode
+    resolves `TERMINATE` with a non-null period)
+  - `wrap-cancelation-period-over-cap-fails` (forwarded period plus an
+    offset resolves over the 600-second cap)
+- **Round-trip forwarding through job instantiation**: the same
+  forwarding pattern with the wrap env declared in `jobEnvironments`, so
+  the template passes through job creation where `WrappedAction.*`
+  cannot exist yet — resolution of the forwarded `timeout` /
+  `notifyPeriodInSeconds` must defer to run time
+  (`wrap-cancelation-roundtrip-job-environment`).
+- **Environment-template scope in hooks**: a wrap environment template's
+  own `parameterDefinitions` and script-level `let` bindings resolve
+  inside all three hooks (`wrap-env-template-parameters-in-hooks`,
+  `wrap-env-let-bindings-in-hooks`) — the wrapped step's symbol table
+  knows nothing about them, so the runtime must carry the environment's
+  own scope to its hooks.
+- **`WrappedAction.Environment` is openjd_env-only** (§4.3.1): an inner
+  environment's declarative `variables:` map must not surface in the
+  forwarded list (`wrap-environment-excludes-variables-map`).
+- **Session-level single-layer rule**: two wrap-defining environments
+  supplied as *separate* environment templates — no single template is
+  invalid, so only the session/runner can reject the stack
+  (`wrap-two-wrap-env-templates-rejected`).
+- **Cleanup guarantee** (RFC 0008 "Lifecycle and cleanup guarantees"):
+  a failed `onWrapEnvEnter` still runs the inner environment's
+  `onWrapEnvExit` and the wrapping environment's own `onExit`, and the
+  failing hook's exit code is the surfaced task failure
+  (`wrap-failed-enter-still-runs-wrap-exit`).
+- **Exit-hook skip**: an inner environment with no `onExit` has nothing
+  to replace, so `onWrapEnvExit` must not fire for it
+  (`wrap-inner-env-without-on-exit-skips-exit-hook`).
 - **`openjd_env` propagation**: variables emitted by a wrapped `onEnter`
   surface in `WrappedAction.Environment` for subsequent wrapped actions
   (`wrap-openjd-env-from-wrapped-onenter-propagates`).
+- **`openjd_fail` propagation**: a failure macro emitted by the wrapped
+  process is recognized through the wrap script's forwarded stdout, and
+  the wrapped exit status propagates
+  (`wrap-openjd-fail-from-wrapped-process`).
 - **Exit-status propagation**: a non-zero wrapped process fails the wrap
   action and therefore the task (`wrap-exit-status-propagates`, plus the
   `-python` and `-windows` variants).
@@ -249,10 +317,18 @@ bundles in this directory:
   - `wrap-without-extension-fails`: hooks require the `WRAP_ACTIONS` extension.
   - `wrap-without-expr-extension`: `WRAP_ACTIONS` requires `EXPR`.
   - `wrap-multiple-wrap-envs-rejected`: at most one wrap env per session.
+  - `wrap-two-wrap-env-templates-rejected`: the same rule across two
+    separately-supplied environment templates (session-level check).
   - `wrap-job-and-step-env-rejected`: single-wrap-layer rule across job and
     step environments.
   - `wrap-partial-hooks-rejected`: all-or-nothing rule (job side).
   - `wrap-wrappedaction-outside-wrap-hook-rejected`: variable scope rule (job side).
+  - `4--wrappedaction-in-cancelation-outside-hook`: scope rule applies to an
+    action's cancelation fields, not just command/args/timeout (env side).
+  - `4--wrappedaction-in-embedded-file`: scope rule applies to embedded file
+    `data` — embedded files are shared by all of the script's actions,
+    including the env's own `onEnter`/`onExit` where `WrappedAction.*`
+    never exists (env side).
   - `4.3--wrap-only-onwrap-task-run`: all-or-nothing rule (env side).
   - `4.3--wrap-missing-onwrap-exit`: all-or-nothing rule (env side).
   - `4.2--empty-actions-no-wrap-no-enter-no-exit`: an `actions` block must

--- a/conformance-tests/2023-09/WRAP_ACTIONS/env_templates/4--wrappedaction-in-cancelation-outside-hook.invalid.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/env_templates/4--wrappedaction-in-cancelation-outside-hook.invalid.yaml
@@ -1,0 +1,32 @@
+# Template Schemas 4 (format string scopes, items 5-7): "Templates must
+# not reference WrappedAction.* outside the three wrap hooks ... Schedulers
+# must reject templates that violate this scope rule." The scope rule
+# covers EVERY format-string field of an action — the existing scope
+# fixture covers args; this one pins the cancelation fields, where the
+# reference is easy to write by copy-pasting the round-trip forwarding
+# pattern into the wrong action. The env's own onEnter is not a wrap hook,
+# so its cancelation.mode must not reference WrappedAction.* even though
+# the same template legitimately uses the namespace inside its hooks.
+specificationVersion: environment-2023-09
+extensions:
+- WRAP_ACTIONS
+- EXPR
+- FEATURE_BUNDLE_1
+environment:
+  name: WrapEnv
+  script:
+    actions:
+      onEnter:
+        command: bash
+        args: ["-c", "echo own enter"]
+        cancelation:
+          mode: "{{WrappedAction.Cancelation.Mode}}"
+      onWrapEnvEnter:
+        command: bash
+        args: ["-c", "echo {{WrappedAction.Command}}"]
+      onWrapTaskRun:
+        command: bash
+        args: ["-c", "echo {{WrappedAction.Command}}"]
+      onWrapEnvExit:
+        command: bash
+        args: ["-c", "echo {{WrappedAction.Command}}"]

--- a/conformance-tests/2023-09/WRAP_ACTIONS/env_templates/4--wrappedaction-in-embedded-file.invalid.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/env_templates/4--wrappedaction-in-embedded-file.invalid.yaml
@@ -1,0 +1,28 @@
+# Template Schemas 4 (format string scopes, items 5-7): WrappedAction.*
+# may be referenced only within the three wrap hooks. An
+# <EnvironmentScript>'s embeddedFiles are shared by ALL of the script's
+# actions — including the environment's own onEnter/onExit, where
+# WrappedAction.* never exists — so a WrappedAction.* reference in an
+# embedded file's data is outside the hooks' scope and must be rejected
+# at validation time rather than failing (or half-working) at run time.
+specificationVersion: environment-2023-09
+extensions:
+- WRAP_ACTIONS
+- EXPR
+environment:
+  name: WrapEnv
+  script:
+    embeddedFiles:
+    - name: Helper
+      type: TEXT
+      data: "wrapped command is {{WrappedAction.Command}}"
+    actions:
+      onWrapEnvEnter:
+        command: bash
+        args: ["-c", "echo enter"]
+      onWrapTaskRun:
+        command: bash
+        args: ["-c", "echo task"]
+      onWrapEnvExit:
+        command: bash
+        args: ["-c", "echo exit"]

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-mode-resolves-invalid-fails.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-mode-resolves-invalid-fails.test.yaml
@@ -1,0 +1,52 @@
+# Template Schemas 5.3: when a format-string cancelation mode resolves,
+# "Any other resolved value is an error; the runtime MUST fail the action."
+# A constant expression could be folded and rejected during validation, so
+# this fixture builds the invalid value from WrappedAction.* — seeded
+# per-action at host evaluation time, unknowable statically or at job
+# creation: the wrapped action's mode (NOTIFY_THEN_TERMINATE) with the
+# literal suffix "_GARBAGE" resolves to "NOTIFY_THEN_TERMINATE_GARBAGE",
+# which is neither of the two method names nor null. The runtime must
+# fail the wrapped task when it prepares to run the action, and the
+# action's own script must never execute: a runtime that only inspects
+# the cancelation lazily (at cancel time) would run this action to
+# success and silently ignore the author's (typo'd) forwarding.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationModeResolvesInvalidFails
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: 45
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo WRAP ENTER"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo GARBAGE MODE TASK RAN"]
+          cancelation:
+            mode: "{{WrappedAction.Cancelation.Mode}}_GARBAGE"
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo WRAP EXIT"]
+runOn:
+- posix
+expected:
+  taskFailure: {}
+  forbidden:
+  - "GARBAGE MODE TASK RAN"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-period-over-cap-fails.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-period-over-cap-fails.test.yaml
@@ -1,0 +1,51 @@
+# Template Schemas 5.3.2: notifyPeriodInSeconds has a maximum value of
+# 600. A literal 700 is rejected at parse time, and a constant expression
+# like "{{ 700 }}" may equally be folded and rejected during validation —
+# so this fixture derives the out-of-range value from WrappedAction.*,
+# which is seeded per-action at host evaluation time and cannot be known
+# statically or at job creation: the wrapped action's forwarded period
+# (45) plus 655 resolves to 700 only when the hook is about to run. The
+# runtime must enforce the bound at resolution and fail the action;
+# otherwise the 600-second cap is bypassable by any run-time-derived
+# expression.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationPeriodOverCapFails
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: 45
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo WRAP ENTER"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo PERIOD OVER CAP TASK RAN"]
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: "{{ WrappedAction.Cancelation.NotifyPeriodInSeconds + 655 }}"
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo WRAP EXIT"]
+runOn:
+- posix
+expected:
+  taskFailure: {}
+  forbidden:
+  - "PERIOD OVER CAP TASK RAN"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-job-environment.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-roundtrip-job-environment.test.yaml
@@ -1,0 +1,57 @@
+# Round-trip cancelation + timeout forwarding with the wrap environment
+# defined in the JOB template's jobEnvironments — not an external
+# environment template. Wrap hooks in jobEnvironments/stepEnvironments
+# are spec-supported, and this placement routes the template through job
+# instantiation (create_job), where the WrappedAction.* symbols cannot
+# exist yet: implementations that eagerly resolve creation-scoped fields
+# (timeout, notifyPeriodInSeconds) at instantiation reject this template
+# with "Undefined variable" even though it is valid. Every other
+# round-trip fixture uses external environment templates, which never
+# pass through create_job — so only this fixture pins the
+# instantiation-time deferral.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  name: WrapCancelationRoundtripJobEnvironment
+  jobEnvironments:
+  - name: WrapRT
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo \"RT MODE=[{{WrappedAction.Cancelation.Mode}}] NP=[{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}] T=[{{WrappedAction.Timeout}}]\""
+          timeout: "{{WrappedAction.Timeout}}"
+          cancelation:
+            mode: "{{WrappedAction.Cancelation.Mode}}"
+            notifyPeriodInSeconds: "{{WrappedAction.Cancelation.NotifyPeriodInSeconds}}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          timeout: 300
+          cancelation:
+            mode: NOTIFY_THEN_TERMINATE
+            notifyPeriodInSeconds: 45
+runOn:
+- posix
+expected:
+  output:
+  - "RT MODE=[NOTIFY_THEN_TERMINATE] NP=[45] T=[300]"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-terminate-with-period-fails.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-cancelation-terminate-with-period-fails.test.yaml
@@ -1,0 +1,52 @@
+# Template Schemas 5.3: when a format-string cancelation mode resolves to
+# "TERMINATE" or "NOTIFY_THEN_TERMINATE", the object "MUST then validate
+# against that form's schema". TERMINATE admits no notifyPeriodInSeconds,
+# so a mode resolving to TERMINATE alongside a non-null period is a
+# run-time validation error and the runtime must fail the action before
+# its script executes. The mode here is forwarded from WrappedAction.* —
+# seeded per-action at host evaluation time, so which form the object
+# takes is genuinely unknowable statically or at job creation (the same
+# wrap env may wrap actions with different modes). At parse time this
+# shape is legal by design: a deferred mode accepts the union of both
+# forms' fields, and the shape check moves to resolution time — this
+# fixture pins that deferred check.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapCancelationTerminateWithPeriodFails
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+          cancelation:
+            mode: TERMINATE
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  - FEATURE_BUNDLE_1
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo WRAP ENTER"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo TERMINATE PLUS PERIOD TASK RAN"]
+          cancelation:
+            mode: "{{WrappedAction.Cancelation.Mode}}"
+            notifyPeriodInSeconds: 45
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo WRAP EXIT"]
+runOn:
+- posix
+expected:
+  taskFailure: {}
+  forbidden:
+  - "TERMINATE PLUS PERIOD TASK RAN"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-env-let-bindings-in-hooks.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-env-let-bindings-in-hooks.test.yaml
@@ -1,0 +1,57 @@
+# Template Schemas 4.2: an <EnvironmentScript>'s `let` bindings are
+# "evaluated once when the environment is entered" and the bound names
+# "are available in *actions*" — the wrap hooks are actions of the wrap
+# environment's script, so a wrap env's own let-bound names must resolve
+# inside its hooks. This is the wrap-env analogue of ordinary env-script
+# lets and matters for exactly the same reason parameters do: reusable
+# wrap templates compute derived values (image tags, mount paths) once
+# with `let` and reference them from every hook. The wrapped step's
+# symbol table knows nothing about these names, so the runtime must
+# carry the wrap environment's own let scope to its hooks.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapEnvLetBindingsInHooks
+  jobEnvironments:
+  - name: InnerEnv
+    script:
+      actions:
+        onEnter:
+          command: bash
+          args: ["-c", "echo INNER ENTER BODY"]
+        onExit:
+          command: bash
+          args: ["-c", "echo INNER EXIT BODY"]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapLet
+    script:
+      let:
+      - greeting = 'FROM_ENV_LET'
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo LENTER {{ greeting }}"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo LTASK {{ greeting }}"]
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo LEXIT {{ greeting }}"]
+runOn:
+- posix
+expected:
+  output:
+  - "LENTER FROM_ENV_LET"
+  - "LTASK FROM_ENV_LET"
+  - "LEXIT FROM_ENV_LET"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-env-template-parameters-in-hooks.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-env-template-parameters-in-hooks.test.yaml
@@ -1,0 +1,60 @@
+# A wrap environment template parameterized through its own
+# parameterDefinitions — the natural way to write a reusable wrapper
+# (container image name, mount prefix, ...) and how RFC 0008's motivating
+# examples read. The environment's format-string scope includes Param.*
+# (Template Schemas §4), so {{Param.Prefix}} must resolve inside all
+# three wrap hooks from the environment template's own parameter
+# defaults. This exercises a path the other fixtures never touch: the
+# wrap-task hook resolves against a symbol table derived from the
+# wrapped STEP, which knows nothing about the wrap env's parameters —
+# the runtime must carry the environment's own parameter scope to its
+# hooks itself.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapEnvTemplateParametersInHooks
+  jobEnvironments:
+  - name: InnerEnv
+    script:
+      actions:
+        onEnter:
+          command: bash
+          args: ["-c", "echo INNER ENTER BODY"]
+        onExit:
+          command: bash
+          args: ["-c", "echo INNER EXIT BODY"]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  parameterDefinitions:
+  - name: Prefix
+    type: STRING
+    default: FROM_ENV_PARAM
+  environment:
+    name: WrapParam
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo PENTER {{Param.Prefix}}"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo PTASK {{Param.Prefix}}"]
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo PEXIT {{Param.Prefix}}"]
+runOn:
+- posix
+expected:
+  output:
+  - "PENTER FROM_ENV_PARAM"
+  - "PTASK FROM_ENV_PARAM"
+  - "PEXIT FROM_ENV_PARAM"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-environment-excludes-variables-map.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-environment-excludes-variables-map.test.yaml
@@ -1,0 +1,62 @@
+# Template Schemas 4.3.1: "WrappedAction.Environment carries only
+# openjd_env-defined variables from the current session". An inner
+# environment's declarative `variables:` map is applied to the real
+# subprocess environment by the runtime, but it is NOT an openjd_env
+# export and must not appear in the forwarded list — the wrapping
+# environment is responsible for host-side variables. This fixture pins
+# the exclusion: the inner env declares STATIC_VAR via `variables:` and
+# exports DYNAMIC_VAR via openjd_env (emitted by its wrapped onEnter,
+# forwarded verbatim by the wrap hook); only DYNAMIC_VAR may surface.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapEnvironmentExcludesVariablesMap
+  jobEnvironments:
+  - name: InnerVars
+    variables:
+      STATIC_VAR: hello
+    script:
+      actions:
+        onEnter:
+          command: bash
+          args: ["-c", "echo 'openjd_env: DYNAMIC_VAR=world'"]
+        onExit:
+          command: bash
+          args: ["-c", "echo INNER EXIT BODY"]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "printf 'ENVLINE=%s\\n' {{ repr_sh(WrappedAction.Environment) }}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+runOn:
+- posix
+expected:
+  output:
+  - "ENVLINE=DYNAMIC_VAR=world"
+  forbidden:
+  - "ENVLINE=STATIC_VAR"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-failed-enter-still-runs-wrap-exit.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-failed-enter-still-runs-wrap-exit.test.yaml
@@ -1,0 +1,72 @@
+# RFC 0008 "Lifecycle and cleanup guarantees", scenario row 1:
+# "onWrapEnvEnter fails for inner env B → onWrapEnvExit for B; wrapping
+# environment's onExit." A failed onWrapEnvEnter is an inner onEnter
+# failure (failure semantics), and the session's cleanup guarantee means
+# the inner environment must still be exited THROUGH the wrap layer
+# (onWrapEnvExit) and the wrapping environment's own onExit must run on
+# top — resources allocated by the wrapping environment's onEnter (a
+# container) must remain available until every onWrapEnvExit returns,
+# then be released. A runner that aborts on the enter failure without
+# running the exits leaks whatever the wrap env's onEnter started.
+#
+# The failing hook exits 7 so the taskFailure assertion can verify the
+# FIRST non-zero exit is the failed enter; the cleanup actions that run
+# after it exit 0.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapFailedEnterStillRunsWrapExit
+  jobEnvironments:
+  - name: InnerEnv
+    script:
+      actions:
+        onEnter:
+          command: bash
+          args: ["-c", "echo INNER ENTER BODY"]
+        onExit:
+          command: bash
+          args: ["-c", "echo INNER EXIT BODY"]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: bash
+          args: ["-c", "echo TASK BODY RAN"]
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onEnter:
+          command: bash
+          args: ["-c", "echo WRAPENV OWN ENTER RAN"]
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo WRAP ENTER FAILING; exit 7"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo WRAP TASK RAN"]
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo WRAP EXIT RAN for {{WrappedEnv.Name}}"]
+        onExit:
+          command: bash
+          args: ["-c", "echo WRAPENV OWN EXIT RAN"]
+runOn:
+- posix
+expected:
+  taskFailure:
+    exitCode: 7
+  output:
+  - "WRAPENV OWN ENTER RAN"
+  - "WRAP ENTER FAILING"
+  - "WRAP EXIT RAN for InnerEnv"
+  - "WRAPENV OWN EXIT RAN"
+  forbidden:
+  - "TASK BODY RAN"
+  - "INNER ENTER BODY"
+  - "INNER EXIT BODY"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-inner-env-without-on-exit-skips-exit-hook.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-inner-env-without-on-exit-skips-exit-hook.test.yaml
@@ -1,11 +1,11 @@
-# Template Schemas 4.3 / How-Jobs-Are-Run: onWrapEnvExit "runs instead of
-# the onExit action of every inner environment". When the inner
-# environment defines no onExit there is nothing to replace, so the exit
-# hook must NOT fire for that environment — a runtime that runs the hook
-# unconditionally would execute wrapper teardown logic (e.g. a container
-# exec) against an action that does not exist. onEnter is required by the
-# base schema, so the enter side of this edge is unrepresentable; this
-# fixture pins the testable exit half.
+# Template Schemas 4.3, WRAP_ACTIONS constraint 5 (nothing-to-replace
+# rule): "A wrap hook runs only in place of an action the inner entity
+# defines." When the inner environment defines no onExit there is nothing
+# to replace, so the exit hook must NOT fire for that environment — a
+# runtime that runs the hook unconditionally would execute wrapper
+# teardown logic (e.g. a container exec) against an action that does not
+# exist. onEnter is required by the base schema, so the enter side of
+# this edge is unrepresentable; this fixture pins the testable exit half.
 template:
   specificationVersion: jobtemplate-2023-09
   name: WrapInnerEnvWithoutOnExitSkipsExitHook

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-inner-env-without-on-exit-skips-exit-hook.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-inner-env-without-on-exit-skips-exit-hook.test.yaml
@@ -1,0 +1,52 @@
+# Template Schemas 4.3 / How-Jobs-Are-Run: onWrapEnvExit "runs instead of
+# the onExit action of every inner environment". When the inner
+# environment defines no onExit there is nothing to replace, so the exit
+# hook must NOT fire for that environment — a runtime that runs the hook
+# unconditionally would execute wrapper teardown logic (e.g. a container
+# exec) against an action that does not exist. onEnter is required by the
+# base schema, so the enter side of this edge is unrepresentable; this
+# fixture pins the testable exit half.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapInnerEnvWithoutOnExitSkipsExitHook
+  jobEnvironments:
+  - name: EnterOnlyEnv
+    script:
+      actions:
+        onEnter:
+          command: bash
+          args: ["-c", "echo ENTERONLY BODY"]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: echo
+          args: ["placeholder"]
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo WRAPENTER for {{WrappedEnv.Name}}"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo WRAPTASK RAN"]
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo WRAPEXIT for {{WrappedEnv.Name}}"]
+runOn:
+- posix
+expected:
+  output:
+  - "WRAPENTER for EnterOnlyEnv"
+  - "WRAPTASK RAN"
+  forbidden:
+  - "WRAPEXIT for EnterOnlyEnv"
+  - "ENTERONLY BODY"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-openjd-fail-from-wrapped-process.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-openjd-fail-from-wrapped-process.test.yaml
@@ -1,0 +1,53 @@
+# RFC 0008 "Stdout forwarding and macro propagation": runtimes MUST scan
+# the wrap script's stdout for OpenJD macros, and because wrap scripts
+# forward the wrapped process's stdout verbatim, "a macro emitted by a
+# wrapped process is recognized identically to one emitted by the wrap
+# script itself". The openjd_env case is already pinned
+# (wrap-openjd-env-from-wrapped-onenter-propagates); this fixture pins a
+# second macro, openjd_fail: the wrapped task's onRun emits a failure
+# message and exits 3, the wrap hook re-invokes it verbatim, and the
+# failure (message line + propagated exit status) must surface exactly as
+# in the unwrapped case.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: WrapOpenjdFailFromWrappedProcess
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: bash
+          args:
+          - "-c"
+          - "echo 'openjd_fail: wrapped process failure message'; exit 3"
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapEnv
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapTaskRun:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+        onWrapEnvExit:
+          command: bash
+          args:
+          - "-c"
+          - "{{ repr_sh(WrappedAction.Command) }} {{ repr_sh(WrappedAction.Args) }}"
+runOn:
+- posix
+expected:
+  taskFailure:
+    exitCode: 3
+  output:
+  - "openjd_fail: wrapped process failure message"

--- a/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-two-wrap-env-templates-rejected.invalid.test.yaml
+++ b/conformance-tests/2023-09/WRAP_ACTIONS/jobs/wrap-two-wrap-env-templates-rejected.invalid.test.yaml
@@ -1,0 +1,58 @@
+# RFC 0008 / How-Jobs-Are-Run: "If more than one Environment in the
+# session stack defines any wrap hook, the session is invalid and the
+# scheduler must reject it before entering any Environment."
+#
+# The existing wrap-multiple-wrap-envs-rejected fixture stacks two wrap
+# environments inside ONE job template, which template validation can
+# catch. This fixture supplies the two wrap environments as SEPARATE
+# environment templates — no single template is invalid, so the rule can
+# only be enforced by the session/runner at enter time. A runner that
+# skips the session-level check silently runs only the innermost wrap
+# env's hooks, dropping the outer wrap layer's containment entirely.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: TwoWrapEnvTemplatesRejected
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: bash
+          args: ["-c", "echo TASK BODY RAN"]
+environments:
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapA
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo WRAP A ENTER"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo WRAP A TASK"]
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo WRAP A EXIT"]
+- specificationVersion: environment-2023-09
+  extensions:
+  - WRAP_ACTIONS
+  - EXPR
+  environment:
+    name: WrapB
+    script:
+      actions:
+        onWrapEnvEnter:
+          command: bash
+          args: ["-c", "echo WRAP B ENTER"]
+        onWrapTaskRun:
+          command: bash
+          args: ["-c", "echo WRAP B TASK"]
+        onWrapEnvExit:
+          command: bash
+          args: ["-c", "echo WRAP B EXIT"]
+runOn:
+- posix

--- a/rfcs/0008-environment-wrap-actions.md
+++ b/rfcs/0008-environment-wrap-actions.md
@@ -283,6 +283,17 @@ A wrapping environment's wrap hooks intercept only the actions of inner
 environments and tasks. The wrapping environment's own `onEnter` and `onExit`
 are never wrapped.
 
+**Nothing-to-replace rule.** A wrap hook runs only in place of an action the
+inner entity actually defines. When an inner environment defines no `onExit`
+— or defines no `script` at all (a `variables:`-only environment) — there is
+nothing to replace, and the runtime MUST NOT run the corresponding wrap hook
+for that environment. A hook is a *replacement*, not a lifecycle
+notification: running `onWrapEnvExit` against a nonexistent `onExit` would
+execute wrapper teardown logic (for example, a container exec) for an action
+that was never going to run, with `WrappedAction.Command`/`Args` having no
+meaningful values. Every `<StepScript>` defines `onRun`, so `onWrapTaskRun`
+runs for every task.
+
 ### Template variables
 
 The following variables are read-only context supplied by the runtime to wrap
@@ -370,7 +381,10 @@ script does not propagate it behaves as if the field were absent.
 + - An inner Environment's onExit is replaced by the wrapping Environment's onWrapEnvExit.
 +
 + The wrapping Environment's own onEnter and onExit are never wrapped; they always run
-+ normally. If more than one Environment in the session stack defines any wrap hook,
++ normally. A wrap hook runs only in place of an action the inner Environment defines:
++ if an inner Environment defines no onExit (or defines no script at all), there is
++ nothing to replace and the corresponding wrap hook does not run for it. If more than
++ one Environment in the session stack defines any wrap hook,
 + the session is invalid and the scheduler must reject it before entering any
 + Environment. If an environment defines any wrap hook, it must define all three.
 ```

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -1601,6 +1601,11 @@ onExit: <Action> # optional
 >    Schedulers must reject templates that list `WRAP_ACTIONS` without also listing `EXPR`.
 > 4. The wrapping environment's own `onEnter` and `onExit` are never wrapped; they always run
 >    normally.
+> 5. *Nothing-to-replace rule.* A wrap hook runs only in place of an action the inner entity
+>    defines. When an inner environment defines no `onExit` — or defines no `script` at all (a
+>    `variables:`-only environment) — there is nothing to replace, and the corresponding wrap
+>    hook must not run for that environment. Every `<StepScript>` defines `onRun`, so
+>    `onWrapTaskRun` runs for every task.
 
 #### 4.3.1. Wrap hook template variables
 

--- a/wiki/How-Jobs-Are-Run.md
+++ b/wiki/How-Jobs-Are-Run.md
@@ -38,7 +38,10 @@ the lifecycle actions of inner Environments and tasks
 are intercepted: an inner Environment's `onEnter` is replaced by the wrapping Environment's
 `onWrapEnvEnter`, a task's `onRun` is replaced by the wrapping Environment's `onWrapTaskRun`, and an inner
 Environment's `onExit` is replaced by the wrapping Environment's `onWrapEnvExit`. The wrapping Environment's
-own `onEnter` and `onExit` are never wrapped; they always run normally. If more than one Environment
+own `onEnter` and `onExit` are never wrapped; they always run normally. A wrap hook runs only in place
+of an action the inner Environment defines: if an inner Environment defines no `onExit` (or defines no
+script at all), there is nothing to replace and the corresponding wrap hook does not run for it. If more
+than one Environment
 in the session stack defines any wrap hook, the session is invalid and the scheduler must reject it
 before entering any Environment. If an Environment defines any wrap hook, it must define all three.
 


### PR DESCRIPTION
## Why these conformance tests are needed

A five-pass deep review of the RFC 0008 wrap-actions feature (spec + openjd-rs + openjd-model-for-python + openjd-sessions-for-python) found that **every High-severity cross-runtime divergence lived on a spec-mandated path that no conformance fixture exercised**. The suite was passing 59/59 on both CLIs while the two implementations disagreed about single-layer enforcement, run-time cancelation validation, forwarded environment contents, environment-template scope, and the cleanup guarantee. The review's coverage audit walked every normative statement in Template Schemas §4.2/§4.3/§4.3.1/§5/§5.3, How-Jobs-Are-Run's wrap sections, and RFC 0008's Cancelation/Timeout/Cleanup/Stdout/Failure sections against the fixture list, element by element (positive / negative / edge), and produced the gap list this PR closes.

This PR adds **13 fixtures (59 → 72)**: 11 job execution tests and 2 env-template validation tests. Each fixture's header comment cites the exact spec sentence it pins.

### Fixture-by-fixture rationale

**Run-time cancelation validation — §5.3 steps 1–3 (3 fixtures).** Template Schemas §5.3 says a resolved format-string `mode` "MUST then validate against that form's schema" and "Any other resolved value is an error; the runtime MUST fail the action"; §5.3.2 caps `notifyPeriodInSeconds` at 600. None of this is statically checkable — expression values only exist at run time — and the suite had **zero** fixtures for it, which is exactly why one runtime shipped without launch-time enforcement (a typo'd forwarding expression is silently ignored and the wrapped task runs as if the author's cancelation semantics were honored):
- `wrap-cancelation-mode-resolves-invalid-fails` — mode resolves to `GARBAGE`; the action must fail and its script must never run (asserted via `forbidden:`).
- `wrap-cancelation-terminate-with-period-fails` — mode resolves `TERMINATE` with a non-null period; the resolved-shape validation must reject it. Parse time cannot catch this (a deferred mode accepts the union of both forms' fields by design).
- `wrap-cancelation-period-over-cap-fails` — `"{{ 700 }}"` bypasses the parse-time 600 cap; the runtime must enforce the bound at resolution.

**Round-trip forwarding through job instantiation (1 fixture).** All four existing round-trip fixtures place the wrap env in *external* environment templates, which never pass through job creation. `wrap-cancelation-roundtrip-job-environment` moves the identical forwarding pattern into `jobEnvironments`, so it routes through `create_job` — where `WrappedAction.*` cannot exist yet and implementations that eagerly resolve creation-scoped fields (`timeout`, `notifyPeriodInSeconds`) reject a valid template with "Undefined variable". This placement is spec-supported and is the follow-up spec's headline feature; the suite could not see the gap.

**Environment-template scope carried to wrap hooks (2 fixtures).** A reusable wrap template is parameterized (`parameterDefinitions`: container image, mount prefix — the RFC's own motivating examples) and computes derived values with script-level `let`. Both are part of the environment's format-string scope (§4 / §4.2), yet no fixture referenced either from a wrap hook — and the wrap-task hook resolves against a symbol table derived from the wrapped *step*, which knows nothing about the wrap env's own scope, so the runtime must carry it explicitly:
- `wrap-env-template-parameters-in-hooks` — `{{Param.Prefix}}` from the env template's own defaults, in all three hooks.
- `wrap-env-let-bindings-in-hooks` — `let greeting = ...` referenced from all three hooks.

**`WrappedAction.Environment` is openjd_env-only (1 fixture).** §4.3.1: the variable "carries only `openjd_env`-defined variables from the current session"; host-side variables are the wrapping environment's responsibility. `wrap-environment-excludes-variables-map` pins both directions with `output:` + `forbidden:`: an inner env's `openjd_env` export must appear, its declarative `variables:` entry must not. The review found the two runtimes handing different byte lists to the same wrap script here.

**Session-level single-layer rule (1 fixture).** How-Jobs-Are-Run: "If more than one Environment in the session stack defines any wrap hook, the session is invalid and the scheduler must reject it before entering any Environment." The existing `wrap-multiple-wrap-envs-rejected` stacks both wrap envs inside **one** job template — template validation catches that. `wrap-two-wrap-env-templates-rejected` supplies them as **separate** environment templates, where no single template is invalid and only the session/runner can enforce the rule. Without it, a runner that skips the session check silently runs only the innermost wrap env — the outer wrap layer's containment (potentially security-relevant) just doesn't happen, and the suite stays green.

**Cleanup guarantee (1 fixture).** RFC 0008's "Lifecycle and cleanup guarantees" scenario table had zero fixtures — previously hard to express, now possible with the runner's `taskFailure` exit-code assertion. `wrap-failed-enter-still-runs-wrap-exit` pins row 1: a failed `onWrapEnvEnter` (exit 7) must still run the inner env's `onWrapEnvExit` and the wrapping env's own `onExit`, surface exit code 7 as the failure, and never run the task. This is the "container leak" scenario: a runner that aborts without the exits orphans whatever the wrap env's `onEnter` started.

**Interception edge (1 fixture).** `onWrapEnvExit` "runs instead of the `onExit` action" — when the inner env defines no `onExit` there is nothing to replace, so the hook must not fire. `wrap-inner-env-without-on-exit-skips-exit-hook` pins the skip (both runtimes agree today; nothing pinned it). The enter-side twin is unrepresentable because the base schema requires `onEnter`.

**Macro propagation beyond `openjd_env` (1 fixture).** RFC 0008: runtimes MUST scan the wrap script's stdout for OpenJD macros, and verbatim forwarding makes a wrapped process's macro "recognized identically". Only `openjd_env` was pinned. `wrap-openjd-fail-from-wrapped-process` covers `openjd_fail` plus exit-status propagation (exit 3) through the wrap layer.

**Variable-scope rule beyond action args (2 env-template fixtures).** §4 items 5–7: schedulers must reject `WrappedAction.*` outside the three hooks. The one existing scope fixture covers action `args` on the job side. The review found scope enforcement regressing per-field on both implementations at different times — first one runtime missed cancelation fields, then the other — so these pin the two field classes that actually diverged:
- `4--wrappedaction-in-cancelation-outside-hook.invalid` — the env's own `onEnter` forwarding `cancelation.mode` (an easy copy-paste mistake from the round-trip pattern).
- `4--wrappedaction-in-embedded-file.invalid` — embedded file `data`; embedded files are shared by *all* the script's actions, including the env's own `onEnter`/`onExit` where `WrappedAction.*` never exists.

### Current implementation status (expected — these fixtures pin spec text, not current behavior)

Verified against both in-development CLIs before opening this PR:

| CLI | Result | Failing fixtures ↔ known open findings |
|---|---|---|
| openjd-rs (with OpenJobDescription/openjd-rs#265) | **69/72** | lets-in-hooks (F12), variables-map exclusion (F9), cleanup guarantee (F15) |
| openjd-sessions-for-python (RFC 0008 branch) | **68/72** | the three runtime cancelation-validation fixtures (F5) and the jobEnvironments round-trip (F2) |

Every failure maps one-to-one onto an already-tracked finding from the review, with fixes queued (Rust top-three already landed in openjd-rs#265; remaining Rust items and the Python items are next — we will endeavor to fix all major issues). The 6 fixtures where both implementations already agree are green on both. Per the conformance workflow's existing policy ("We expect some tests to fail with the openjd CLI at the moment"), red fixtures document spec/implementation gaps rather than blocking; as the queued fixes land, these flip green and become permanent regression protection.

The WRAP_ACTIONS README's layout and statement-to-fixture mapping are updated for all 13.
