### PR TITLE
test: Add 13 extended-parameter-type conformance fixtures

### DIFF
--- a/conformance-tests/2023-09/EXPR/job_templates/2--triple-nested-list-type.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2--triple-nested-list-type.invalid.yaml
@@ -1,0 +1,20 @@
+# Section 2: the list parameter types are exactly LIST[STRING], LIST[PATH],
+# LIST[INT], LIST[FLOAT], LIST[BOOL], and LIST[LIST[INT]]. Deeper nesting
+# such as LIST[LIST[LIST[INT]]] is not a valid type and must be rejected.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Cube
+  type: "LIST[LIST[LIST[INT]]]"
+  default: [[[1]]]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2--type-case-mixed-weird.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2--type-case-mixed-weird.yaml
@@ -1,0 +1,50 @@
+# With EXPR enabled, job parameter type names are case-insensitive.
+# 2--type-case-insensitive.yaml tests one spelling per type; this fixture
+# tests adversarial mixed-case spellings that an implementation matching on
+# a fixed set of spellings (rather than case-folding) would reject.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: MyInt
+  type: iNt
+- name: MyFloat
+  type: fLoAt
+- name: MyString
+  type: sTrInG
+- name: MyPath
+  type: PaTh
+- name: MyBool
+  type: bOoL
+  default: true
+- name: MyRangeExpr
+  type: rAnGe_ExPr
+  default: "1-10"
+- name: MyListInt
+  type: "LiSt[iNt]"
+  default: [1, 2]
+- name: MyListString
+  type: "lIsT[StRiNg]"
+  default: ["a"]
+- name: MyListFloat
+  type: "LisT[fLOat]"
+  default: [1.5]
+- name: MyListPath
+  type: "liST[paTH]"
+  default: ["/tmp/a"]
+- name: MyListBool
+  type: "lIsT[bOoL]"
+  default: [true, false]
+- name: MyListListInt
+  type: "LiSt[lIsT[iNt]]"
+  default: [[1], [2, 3]]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2.10--range-expr-endpoint-int64-overflow.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2.10--range-expr-endpoint-int64-overflow.invalid.yaml
@@ -1,0 +1,26 @@
+# Section 2.10 + Expression Language 1.2.1 (int is 64-bit signed; the
+# 3.4.1.1.1 grammar itself says "any integer value" — the bound comes from
+# the EXPR type table): 9223372036854775808 is 2^63, one past the int64
+# maximum, so a range expression containing it as an endpoint must be
+# rejected. Its accept-side boundary pair
+# (2.10--range-expr-endpoint-int64-max.yaml) is parked in the
+# expected-failures PR's proposed/ directory because openjd-rs currently
+# false-rejects endpoints >= 2^62; until that lands, an int32/int62-capped
+# implementation passes this negative for the wrong reason.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Frames
+  type: RANGE_EXPR
+  default: "1-9223372036854775808"
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2.11--list-string-wrong-item-type.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2.11--list-string-wrong-item-type.invalid.yaml
@@ -1,0 +1,20 @@
+# Section 2.11: a LIST[STRING] default is a list of <string>. A numeric
+# element is the wrong item type and must be rejected. Counterpart of the
+# wrong-item-type negatives that exist for the other list types.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Items
+  type: LIST[STRING]
+  default: [123, 456]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2.12--list-path-item-allowed-values.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2.12--list-path-item-allowed-values.yaml
@@ -1,0 +1,21 @@
+# Section 2.12: item.allowedValues constrains each path element to the given
+# values. Positive pair for 2.12--list-path-item-not-in-allowed.invalid.yaml.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Scenes
+  type: LIST[PATH]
+  default: ["/assets/a.blend", "/assets/b.blend"]
+  item:
+    allowedValues: ["/assets/a.blend", "/assets/b.blend", "/assets/c.blend"]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2.12--list-path-item-not-in-allowed.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2.12--list-path-item-not-in-allowed.invalid.yaml
@@ -1,0 +1,23 @@
+# Section 2.12: item.allowedValues is "An array of the values that each item
+# is allowed to be". A default element outside the list must be rejected.
+# Differs from 2.12--list-path-item-allowed-values.yaml only in the
+# out-of-list element.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Scenes
+  type: LIST[PATH]
+  default: ["/assets/a.blend", "/assets/z.blend"]
+  item:
+    allowedValues: ["/assets/a.blend", "/assets/b.blend", "/assets/c.blend"]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2.13--list-int-item-int64-max.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2.13--list-int-item-int64-max.yaml
@@ -1,0 +1,25 @@
+# Section 2.13 + Expression Language 1.2.1: a LIST[INT] default element at
+# exactly 2^63-1 (the int64 maximum — the bound comes from the EXPR type
+# table, not 2.13 itself) must be ACCEPTED. Pins the full int64 element
+# range against int32-narrowed or float64-backed parsing. The reject twin
+# (element at 2^63) is parked in the expected-failures PR's proposed/
+# because both implementations currently accept it. Note: this tests the
+# element VALUE range, not an `item:` constraint block (LIST[INT] has one,
+# but it is not exercised here).
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Values
+  type: LIST[INT]
+  default: [1, 9223372036854775807]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2.15--list-bool-item-constraints.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2.15--list-bool-item-constraints.invalid.yaml
@@ -1,0 +1,21 @@
+# Section 2.15: the LIST[BOOL] schema has no "item" property (unlike the
+# other list types), so declaring item constraints must be rejected.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Flags
+  type: LIST[BOOL]
+  default: [true, false]
+  item:
+    allowedValues: [true, false]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2.16--list-list-int-inner-item-int64-max.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2.16--list-list-int-inner-item-int64-max.yaml
@@ -1,0 +1,24 @@
+# Section 2.16 + Expression Language 1.2.1: an inner element of a
+# LIST[LIST[INT]] default at exactly 2^63-1 must be ACCEPTED — the int64
+# bound (from the EXPR type table) applies one container level deeper than
+# 2.13's flat-list case, guarding nested validation paths. The reject twin
+# (inner element at 2^63) is parked in the expected-failures PR's
+# proposed/. Note: this tests the inner element VALUE range, not the
+# nested `item.item:` constraint block.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Matrix
+  type: LIST[LIST[INT]]
+  default: [[1, 9223372036854775807], [9223372036854775806]]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/job_templates/2.9--bool-param-allowed-values.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/2.9--bool-param-allowed-values.invalid.yaml
@@ -1,0 +1,20 @@
+# Section 2.9: "BOOL does not support allowedValues". The property is not in
+# the BOOL schema, so declaring it must be rejected.
+specificationVersion: jobtemplate-2023-09
+extensions:
+- EXPR
+name: TestJob
+parameterDefinitions:
+- name: Flag
+  type: BOOL
+  default: true
+  allowedValues: [true]
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/EXPR/jobs/2.12--list-path-indexed-property-access.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.12--list-path-indexed-property-access.test.yaml
@@ -1,0 +1,34 @@
+# Section 2.12 / Expression Language section 2.3.1: path properties must be
+# reachable through a subscripted list element (Param.Paths[0].stem), not
+# only through a scalar path binding like Task.Param.Path.stem.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Paths
+    type: LIST[PATH]
+    default: ["renders/alpha.exr", "renders/beta.png"]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            print(r'STEM0:{{ Param.Paths[0].stem }}:END')
+            print(r'STEM1:{{ Param.Paths[1].stem }}:END')
+            print(r'SUFFIX0:{{ Param.Paths[0].suffix }}:END')
+            print(r'NAME1:{{ Param.Paths[1].name }}:END')
+# The :END terminators make each assertion exact: without them,
+# "STEM0:alpha" is a substring of the wrong answer "STEM0:alpha.exr", so
+# an implementation whose .stem returns .name would pass.
+expected:
+  output:
+  - STEM0:alpha:END
+  - STEM1:beta:END
+  - SUFFIX0:.exr:END
+  - NAME1:beta.png:END

--- a/conformance-tests/2023-09/EXPR/jobs/2.15--list-bool-param-interpolation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.15--list-bool-param-interpolation.test.yaml
@@ -1,0 +1,30 @@
+# LIST[BOOL] interpolation: a bool list embedded in surrounding text renders
+# as a list literal with lowercase true/false elements, with string/int
+# spellings in the default already coerced to bool.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Flags
+    type: LIST[BOOL]
+    default: [true, "no", 1]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            print(r'FLAGS:{{ Param.Flags }}')
+# anyOf: the spec pins lowercase JSON booleans but shows list rendering
+# with ", " separators only by example (EL 1.3.2); a compact-JSON
+# implementation is not plausibly non-conformant, so both spacings pass.
+expected:
+  output:
+  - anyOf:
+    - "FLAGS:[true, false, true]"
+    - "FLAGS:[true,false,true]"

--- a/conformance-tests/2023-09/EXPR/jobs/2.15--list-bool-param-runtime.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.15--list-bool-param-runtime.test.yaml
@@ -1,0 +1,40 @@
+# LIST[BOOL] runtime: element values must reach the task coerced to bool.
+# Exercises a representative sample of the section 2.9/2.15 admitted
+# spellings (bool literal, "false", "yes", "off", "1", int 0); the float
+# 1.0/0.0 forms and the remaining string spellings are not covered here.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Flags
+    type: LIST[BOOL]
+    default: [true, "false", "yes", "off", "1", 0]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            print(r'LEN:{{ len(Param.Flags) }}')
+            print(r'F0:{{ Param.Flags[0] }}')
+            print(r'F1:{{ Param.Flags[1] }}')
+            print(r'F2:{{ Param.Flags[2] }}')
+            print(r'F3:{{ Param.Flags[3] }}')
+            print(r'F4:{{ Param.Flags[4] }}')
+            print(r'F5:{{ Param.Flags[5] }}')
+            print(r'NOT0:{{ not Param.Flags[0] }}')
+expected:
+  output:
+  - LEN:6
+  - F0:true
+  - F1:false
+  - F2:true
+  - F3:false
+  - F4:true
+  - F5:false
+  - NOT0:false


### PR DESCRIPTION
## Summary

13 extended-parameter-type fixtures from a coverage audit of RFC 0007. Suite: **EXPR 350 → 363 passing, 0 failing**; base unchanged.

## Areas covered

- **int64 accept twins on list element types**: `LIST[INT]` element and `LIST[LIST[INT]]` inner element at 2^63−1 accepted — the data-axis boundary the audit found untested for every container type.
- **First-ever `LIST[BOOL]` runtime coverage** (the audit found `EXPR/jobs/` had no `2.15--*` file at all): element values reaching the task, and interpolation rendering. Note: these two fixtures pass on openjd-rs and currently FAIL on the Python CLI (`TypeError: List contains incompatible types: bool, string`) — they are live divergence catchers, green against the reference implementation.
- **Mixed-case type spellings**: `LiSt[iNt]` and friends accepted with EXPR (job parameters).
- **Normative prohibitions**: `BOOL` + `allowedValues` rejected; `item:` on `LIST[BOOL]` rejected; `LIST[LIST[LIST[INT]]]` triple nesting rejected — all stated in the schema, none previously tested.
- **`LIST[PATH]` element constraints**: `item.allowedValues` accept + violation pair (previously appeared in zero fixtures).
- **Indexed-element property access**: `{{Param.Paths[0].stem}}` — the subscript route of the known property-access bug class; verified NOT affected.
- **`RANGE_EXPR` endpoint overflow reject** and a **`LIST[STRING]` wrong-item-type negative** (numeric elements rejected, no silent YAML coercion — verified on both implementations).

## Companion PR

Five spec-correct fixtures that FAIL today (list-element 2^63 acceptance in both implementations, the openjd-rs 2^62 endpoint cap, task-parameter case-insensitivity unimplemented in both, base lowercase type acceptance in openjd-rs) are in the expected-failures PR (branch `conformance-param-types-expected-failures`).
