### PR TITLE
[WIP] test: Promote base int64 and merged-default fixtures into the live suite

### DIFF
--- a/conformance-tests/2023-09/base/job_templates/proposed/2--type-lowercase.invalid.yaml
+++ b/conformance-tests/2023-09/base/job_templates/proposed/2--type-lowercase.invalid.yaml
@@ -1,0 +1,15 @@
+# Parameter type names are case-sensitive in base (case-insensitivity is EXPR-only); 'string' must be rejected.
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+parameterDefinitions:
+- name: MyParam
+  type: string
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-allowedvalues-above-int64-max.invalid.yaml
+++ b/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-allowedvalues-above-int64-max.invalid.yaml
@@ -1,0 +1,17 @@
+# An INT parameter allowedValues entry of 2^63 exceeds the signed 64-bit integer range and must be rejected.
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+parameterDefinitions:
+- name: MyParam
+  type: INT
+  allowedValues:
+  - 9223372036854775808
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print('{{Param.MyParam}}')"

--- a/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-default-above-int64-max.invalid.yaml
+++ b/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-default-above-int64-max.invalid.yaml
@@ -1,0 +1,16 @@
+# An INT parameter default of 2^63 exceeds the signed 64-bit integer range and must be rejected.
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+parameterDefinitions:
+- name: MyParam
+  type: INT
+  default: 9223372036854775808
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print('{{Param.MyParam}}')"

--- a/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-default-below-int64-min.invalid.yaml
+++ b/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-default-below-int64-min.invalid.yaml
@@ -1,0 +1,16 @@
+# An INT parameter default of -2^63-1 is below the signed 64-bit integer range and must be rejected.
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+parameterDefinitions:
+- name: MyParam
+  type: INT
+  default: -9223372036854775809
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print('{{Param.MyParam}}')"

--- a/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-maxvalue-above-int64-max.invalid.yaml
+++ b/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-maxvalue-above-int64-max.invalid.yaml
@@ -1,0 +1,16 @@
+# An INT parameter maxValue of 2^63 exceeds the signed 64-bit integer range and must be rejected.
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+parameterDefinitions:
+- name: MyParam
+  type: INT
+  maxValue: 9223372036854775808
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print('{{Param.MyParam}}')"

--- a/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-minvalue-above-int64-max.invalid.yaml
+++ b/conformance-tests/2023-09/base/job_templates/proposed/2.3--int-minvalue-above-int64-max.invalid.yaml
@@ -1,0 +1,16 @@
+# An INT parameter minValue of 2^63 exceeds the signed 64-bit integer range and must be rejected.
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+parameterDefinitions:
+- name: MyParam
+  type: INT
+  minValue: 9223372036854775808
+steps:
+- name: Step1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print('{{Param.MyParam}}')"

--- a/conformance-tests/2023-09/base/job_templates/proposed/README.md
+++ b/conformance-tests/2023-09/base/job_templates/proposed/README.md
@@ -1,0 +1,57 @@
+# Proposed conformance fixtures (expected failures) — base/job_templates
+
+Every fixture in this directory is parked because it **fails against at least
+one current reference implementation**. Placement is kind-level
+(`<component>/<kind>/proposed/`) so promotion is a mechanical move up one
+directory once the underlying issue is resolved. The conformance runner does
+not scan `proposed/` directories.
+
+Verification environment: `openjd` CLI = openjd-rs release build from
+upstream/main (post range-cap fix); cross-checks with openjd-model-for-python
+0.11.x via `decode_job_template`.
+
+## INT 64-bit boundary rejects
+
+Spec §2.3 types these fields as `<integer>` with **no stated bound** — the
+base 2023-09 document never mentions 64-bit anywhere; the int64 range exists
+only in the Expression Language type table (an EXPR document). Both reference
+implementations nonetheless *store* INT as a signed 64-bit integer, so
+accepted values outside [-2^63, 2^63-1] cannot round-trip and silently
+corrupt.
+
+| Fixture | Construct | Observed |
+|---|---|---|
+| `2.3--int-default-above-int64-max.invalid.yaml` | `default: 9223372036854775808` (2^63) | accepted by **both** (openjd-rs and python) |
+| `2.3--int-minvalue-above-int64-max.invalid.yaml` | `minValue: 9223372036854775808` | accepted by both |
+| `2.3--int-maxvalue-above-int64-max.invalid.yaml` | `maxValue: 9223372036854775808` | accepted by both |
+| `2.3--int-allowedvalues-above-int64-max.invalid.yaml` | `allowedValues: [9223372036854775808]` | accepted by both |
+| `2.3--int-default-below-int64-min.invalid.yaml` | `default: -9223372036854775809` (-2^63-1) | accepted by both |
+
+Classification: **spec question first, then implementation fix** — because the
+base spec states no integer bound, a bignum implementation accepting these is
+arguably conformant as the text stands. Promotion is gated on a base-spec
+integer-bounds erratum (pin `<integer>` to int64 in §2.3); once that lands,
+these become straightforward validation-bug pins, one branch per field. The
+matching accept-twins at 2^63-1 and -2^63 are added by the base-gaps PR
+(`job_templates/2.3--int-*-int64-max.yaml` etc.).
+
+Related, different axis: the *supplied value* case lives in
+`../../jobs/proposed/2.3--int-value-above-int64-max.invalid.test.yaml` — that
+one is **Python-only** (openjd-rs rejects a supplied 2^63 at job creation;
+openjd-model 0.11.x `create_job` accepts it).
+
+## Type-name case sensitivity
+
+| Fixture | Construct | Observed |
+|---|---|---|
+| `2--type-lowercase.invalid.yaml` | `type: string` in base (no `extensions:`) | openjd-rs: **accepted**; python: rejected ("Input tag 'string' ... does not match any of the expected tags") |
+
+Spec §2: `type: "STRING"` is a literal, and the spec states type names become
+case-insensitive only "When the `EXPR` extension is enabled" (see RFC 0007).
+Base is case-sensitive.
+
+Classification: **openjd-rs implementation bug** (unconditional
+case-insensitive type parsing); python is spec-conformant. Note: the
+param-types expected-failures PR previously carried an identical pin
+(`2--type-lowercase-string.invalid.yaml`); it was dropped in favor of this
+one — this fixture is the single copy.

--- a/conformance-tests/2023-09/base/jobs/proposed/1.2.1--constraint-widening-int-range.invalid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/proposed/1.2.1--constraint-widening-int-range.invalid.test.yaml
@@ -1,0 +1,32 @@
+# Spec 1.2.1: each constraint must become MORE constrained in template processing order.
+# The job template (processed last) widens the environment template's INT range, so the
+# merge must be rejected. The default satisfies both ranges, isolating the widening rule.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: TestJob
+  parameterDefinitions:
+  - name: Count
+    type: INT
+    minValue: 0
+    maxValue: 1000
+    default: 50
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print(r'Count={{Param.Count}}')
+environments:
+- specificationVersion: environment-2023-09
+  parameterDefinitions:
+  - name: Count
+    type: INT
+    minValue: 10
+    maxValue: 100
+  environment:
+    name: TestEnv
+    variables:
+      COUNT: '{{Param.Count}}'

--- a/conformance-tests/2023-09/base/jobs/proposed/1.2.1--constraint-widening-minlength.invalid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/proposed/1.2.1--constraint-widening-minlength.invalid.test.yaml
@@ -1,0 +1,30 @@
+# Spec 1.2.1: each constraint must become MORE constrained in template processing order.
+# The job template (processed last) relaxes the environment template's minLength, so the
+# merge must be rejected. The default satisfies both, isolating the widening rule.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: TestJob
+  parameterDefinitions:
+  - name: Value
+    type: STRING
+    minLength: 2
+    default: test-value
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print(r'Value={{Param.Value}}')
+environments:
+- specificationVersion: environment-2023-09
+  parameterDefinitions:
+  - name: Value
+    type: STRING
+    minLength: 5
+  environment:
+    name: TestEnv
+    variables:
+      VAL: '{{Param.Value}}'

--- a/conformance-tests/2023-09/base/jobs/proposed/2.3--int-value-above-int64-max.invalid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/proposed/2.3--int-value-above-int64-max.invalid.test.yaml
@@ -1,0 +1,18 @@
+# A supplied INT parameter value of 2^63 exceeds the signed 64-bit integer range and must be rejected at job creation.
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: TestJob
+  parameterDefinitions:
+  - name: MyParam
+    type: INT
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print(r'OUTPUT:{{Param.MyParam}}')
+parameters:
+  MyParam: 9223372036854775808

--- a/conformance-tests/2023-09/base/jobs/proposed/README.md
+++ b/conformance-tests/2023-09/base/jobs/proposed/README.md
@@ -1,0 +1,46 @@
+# Proposed conformance fixtures (expected failures) — base/jobs
+
+Every fixture in this directory is parked because it **fails against at least
+one current reference implementation**. Placement is kind-level
+(`<component>/<kind>/proposed/`) so promotion is a mechanical move up one
+directory. The conformance runner does not scan `proposed/` directories.
+
+## Merge widening (§1.2.1)
+
+Spec §1.2.1: "each constraint must become more constrained as a subsequent
+definition is merged with the previous ones in processing order" (Job
+Template last). These fixtures have a Job Template that *widens* the
+Environment Template's constraint while the default satisfies both ranges,
+isolating the direction rule from the merged-consistency rule.
+
+| Fixture | Construct | Observed |
+|---|---|---|
+| `1.2.1--constraint-widening-int-range.invalid.test.yaml` | env `[10,100]`, job template `[0,1000]` | accepted by both; job runs |
+| `1.2.1--constraint-widening-minlength.invalid.test.yaml` | env `minLength: 5`, job template `minLength: 2` | accepted by both; job runs |
+
+Cross-check: `openjd.model.merge_job_parameter_definitions` returns the
+*intersection* (`minValue=10, maxValue=100`) rather than rejecting — both
+implementations merge by intersection and never enforce the narrowing
+direction.
+
+Classification: **spec decision needed, then (possibly) implementation fix**.
+The stated sentence supports rejection on a literal reading, but both
+implementations implement intersection semantics, and enforcing
+reject-on-widening is a behavioral change for any scheduler that merges
+externally-supplied environment parameter definitions into customer templates
+(e.g. queue environments). Until the spec either affirms the narrowing rule
+or is revised to define intersection semantics, these stay parked.
+
+## INT 64-bit supplied value (Python-only)
+
+| Fixture | Construct | Observed |
+|---|---|---|
+| `2.3--int-value-above-int64-max.invalid.test.yaml` | supplied INT parameter value `9223372036854775808` (2^63) | openjd-rs: **rejects at job creation (fixture passes)**; python (openjd-model 0.11.x `create_job`): **accepts** |
+
+Moved here from the base-gaps PR's live `jobs/` directory: the base spec
+states no int64 bound on `<integer>` (see the job_templates/proposed README),
+and the reference Python implementation accepts the value, so as a live
+fixture it failed the reference implementation. Same promotion gate as the
+template-side int64 family: a base-spec integer-bounds erratum, plus the
+openjd-model fix. Its accept twin (`jobs/2.3--int-value-int64-max.test.yaml`,
+supplied 2^63-1 resolves exactly) is in the base-gaps PR and passes both.


### PR DESCRIPTION
> [!WARNING]
> **The conformance workflows go red on this PR, deliberately.** These fixtures were parked in
> `base/*/proposed/`, which the runner does not scan, so nothing ran them. They are now live so the
> failures are visible. Six of the twelve are gated on a spec erratum that does not exist yet and
> should not merge before it lands. See "Do not merge as-is" below.

12 fixtures across two families, all `.invalid`. Measured over the full `2023-09/base` suite against
openjd-cli 0.7.7 and openjd-rs `main` e4efd67: Rust 665 passed / 9 failed, Python 668 passed /
6 failed. The base suite has no other failures on either implementation, so every failure belongs to
this PR.

| Fixture | Python | Rust |
|---|---|---|
| `job_templates/2--type-lowercase.invalid.yaml` | pass | pass |
| `job_templates/2.3--int-default-above-int64-max.invalid.yaml` | FAIL | FAIL |
| `job_templates/2.3--int-default-below-int64-min.invalid.yaml` | FAIL | FAIL |
| `job_templates/2.3--int-minvalue-above-int64-max.invalid.yaml` | FAIL | FAIL |
| `job_templates/2.3--int-maxvalue-above-int64-max.invalid.yaml` | FAIL | FAIL |
| `job_templates/2.3--int-allowedvalues-above-int64-max.invalid.yaml` | FAIL | FAIL |
| `job_templates/2.3--int-default-above-int64-max-intstring.invalid.yaml` | FAIL | pass |
| `jobs/1.2.1--merged-default-below-merged-minvalue.invalid.test.yaml` | pass | FAIL |
| `jobs/1.2.1--merged-default-below-merged-minlength.invalid.test.yaml` | pass | FAIL |
| `jobs/1.2.1--merged-default-not-in-merged-allowedvalues-int.invalid.test.yaml` | pass | FAIL |
| `jobs/1.2.1--merged-default-below-merged-minvalue-float.invalid.test.yaml` | pass | FAIL |
| `jobs/2.3--int-value-above-int64-max.invalid.test.yaml` | pass | pass |

## A merged default is not checked against the merged constraint (4 fixtures)

Section 1.2.1 requires the merged job parameter definition to be internally consistent and names the
`default` as its example. Each fixture gives the job template, processed last, a default that
satisfies its own bound but violates the bound merged in from an environment template. Python
refuses all four at job generation. openjd-rs runs them.

Rejection follows under both readings of "each constraint must become more constrained": the literal
one, and the intersection reading proposed in #107. These fixtures do not depend on #107 closing.

Each was probed with a control that both implementations accept, so each isolates one variable:
`default: 50` inside the merged `[10, 100]`, `default: abcdef` at the merged minimum 5, `default: 3`
inside the merged `[1, 2, 3]`, `default: 15.0` above the merged 10.0. The supplied-value equivalents
(`-p Count=5`, `-p Value=abc`) are refused by both, which is what leaves the default uncovered.

Three of the four axes are separate code paths in openjd-rs, not one. `check_constraints` has
separate INT, FLOAT and STRING arms, and the default-vs-`allowedValues` check in
`validate_satisfiable` covers STRING and PATH only. That is why the live
`1.2.1--default-must-satisfy-merged-constraints.invalid.test.yaml` (STRING `allowedValues`) already
passes while the INT `allowedValues` fixture here does not. PATH is deliberately left uncovered:
openjd-rs joins a PATH default to the template directory before checking, so the outcome would
depend on the runner's working directory.

## INT and the int64 boundary (7 fixtures)

Both implementations accept `default`, `minValue`, `maxValue` and `allowedValues` at 2^63 and
`default` at -2^63-1.

What the acceptance costs, measured: openjd-rs accepts `default: 9223372036854775808` at
`openjd check` and then resolves the default to `9223372036854775807` at run time. Silent
saturation, not an error. The Python CLI accepts the same template at `check` and dies at `run` with
`Cannot convert '9223372036854775808' to int: number too large to fit in target type`, raised from
`_serialize_symbol_table` in `_create_job.py`. An uncaught `ValueError`, not validation.

`jobs/2.3--int-value-above-int64-max.invalid.test.yaml` passes on both for that reason, and Python
passes it by accident. Probed directly: `preprocess_job_parameters` accepts the value, `create_job`
accepts it, and only `create_job_with_symbol_tables` rejects. An earlier revision of this branch
claimed the Python CLI accepts it; that is true of `create_job` and false of the CLI.

The `<intstring>` fixture is a falsifiability guard. openjd-rs parses the string form with
`str::parse::<i64>` and already rejects it. Python coerces both forms to an unbounded `int`, so a
fix in `_precheck_is_int_type` that only checks `isinstance(value, int)` would pass all five
bare-integer fixtures and still accept the string.

## Type-name case (1 fixture, passes both)

`2--type-lowercase.invalid.yaml` was parked as an openjd-rs bug. It is not one any more: #364 gated
type-name case on the EXPR extension, and that fix ships in the published `openjd-cli` 0.1.18 the
Rust lane installs. Its positive twin is `EXPR/job_templates/2--type-case-insensitive.yaml`.

## Do not merge as-is

The six int64 fixtures assert a rule the base spec does not state. Section 2.3 types these
properties as `<integer>` and sets no bound; the int64 range appears only in the Expression Language
type table, an EXPR document. A bignum implementation is arguably conformant as the text stands.
They need a section 2.3 integer-bounds erratum first, and no issue for it exists yet. The
saturation measurement above is the case for filing one.

The four merged-default fixtures and `2--type-lowercase` are ready. Splitting them out of this PR is
the fastest way to get a green base suite with the merge gap recorded.

## Two runner limitations found while measuring

Neither is a defect in these fixtures. `run_job` returns `result.returncode == 0` for an `.invalid.`
fixture before it reads `expected`, so a rejection for the wrong reason, or a crash, counts as a
pass. That is how the Python traceback above went unnoticed, and it means adding `expected` entries
to an `.invalid.` fixture has no effect. Separately, a positive `.test.yaml` with no `expected` block
falls through to `return True` without consulting `returncode`, so it passes even when the CLI exits
non-zero.

## Changes in this revision

Every header rewritten to spec, test, expectation. The merged-default headers no longer narrate
openjd-rs internals or point at twin fixtures that live on an unmerged branch, so they stay accurate
once a fix lands. Both `proposed/README.md` inventories deleted; their measurement data is in this
description. Four fixtures added. Non-ASCII characters removed from every fixture, since the runner
opens them at the locale encoding and a UTF-8 character is mojibake on Windows.
