### PR TITLE
fix: clarify Call target-type propagation and dispatch resolution in RFC 0005 

### DIFF
--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-describes-result-not-computation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-describes-result-not-computation.test.yaml
@@ -1,0 +1,46 @@
+# Expression Language §1.3.1: the target type describes the expression's
+# result, never its computation. Each bare "{{expr}}" args item has target
+# type `string? | list[string]` (§1.3.2), so a `list[string]` target is in
+# play — but it must not be unified with `sorted(list[T1]) -> list[T1]`'s
+# return type to bind T1=string into the argument. The argument evaluates
+# unconstrained, the sort is numeric, and only the *result* coerces to
+# list[string] and flattens into the args. An implementation that binds the
+# target through the return type would coerce [10, 2] to ["10", "2"] first
+# and sort lexicographically, producing args in the order 10, 2.
+#
+# The min() item additionally pins that overload resolution and execution do
+# not depend on the target: min's signatures return a type variable, so a
+# target-filtered candidate set may be empty, but the call must still
+# evaluate normally with the int result coercing to string.
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  parameterDefinitions:
+  - name: Ints
+    type: LIST[INT]
+    default: [10, 2]
+  steps:
+  - name: Step1
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            import sys
+            print('ARGS:' + ','.join(sys.argv[1:]))
+          - "{{ sorted(Param.Ints) }}"
+          - SEP
+          - "{{ Param.Ints.sorted() }}"
+          - SEP
+          - "{{ min(Param.Ints) }}"
+expected:
+  output:
+  - "ARGS:2,10,SEP,2,10,SEP,2"
+  forbidden:
+  # Lexicographic order would mean the list[string] target was bound
+  # through the return type and coerced the argument before sorting.
+  - "ARGS:10,2"

--- a/rfcs/0005-expression-language.md
+++ b/rfcs/0005-expression-language.md
@@ -762,7 +762,14 @@ conversions are attempted:
 - `int` → `float` when the target types do not include `int`
 - `path` → `string` when the target types do not include `path`
 - `range_expr` → `string` when the target types do not include `range_expr` (produces canonical form like `"1-5"`)
-- `range_expr` → `list[int]` when the target types include `list[int]` but not `range_expr`
+- `range_expr` → `list[int]` when the target types include `list[int]` but not `range_expr`.
+  This is the only list type a `range_expr` implicitly coerces to: a `list[T]` target with any
+  other element type (e.g. `list[float]` or `list[string]`) is an error. (A `list[any]` target
+  is also accepted, since a `list[int]` value already satisfies it.) Implicit rules do not
+  chain, so the materialized `list[int]` is not further widened element-wise toward the target.
+  A template that wants the widened list can chain the explicit conversion
+  `list(value: range_expr) -> list[int]` (RFC 0006) — e.g. `list(r)` in a `list[string]`
+  context — where the `list[T]` → `list[U]` rule below then applies to the conversion's result.
 - `list[T]` → `list[U]` when each element `T` can be coerced to `U` (e.g., `list[path]` → `list[string]`)
 - `list[nulltype]` → `list[T]` for any `T` (empty list literal is compatible with any list type)
 - Any scalar value when the target types have a single scalar type (without counting `nulltype` or `list[T]` for any `T`).
@@ -776,6 +783,42 @@ conversions are attempted:
 - `[v1, v2, v3, ...]` any values when the target types have a single `list` type (without counting `list[nulltype]`).
   Every value is coerced non-destructively to `T` where that type is `list[T]`. This applies recursively
   for nested lists. The non-destructive coercions are the same as defined for scalar values above.
+
+A **type variable** target (`T`, `T1`, `T2`, `T3`) has no coercion rule, for concrete and
+unresolved values alike. Type variables are placeholders in generic function signatures,
+resolved to concrete types by signature matching before any value is coerced (see the
+Target Type Propagation Rules in [Expression Evaluation](#expression-evaluation)), so reaching coercion with
+one still unbound is always an error. Accepting a type-variable target for unresolved values
+would let validation pass an expression that can only fail once the value is known.
+
+#### Coercion of Unresolved Values
+
+Target-type coercion applies the same conversion table to `unresolved[T]` values at the type
+level: the payload remains unresolved, but its constraint is narrowed to the coercion result.
+For example, `unresolved[int]` against a `string` target becomes `unresolved[string]`, and a
+`range_expr` → `list[int]` coercion of an unresolved value yields `unresolved[list[int]]`.
+
+When the constraint is a union, coercion is existential: it succeeds if at least one member of
+the union can coerce to the target, and the possibilities that cannot are discarded. Coercing
+`unresolved[int | string]` to an `int` target yields `unresolved[int]`, and
+`unresolved[int | list[int]]` to `int` also yields `unresolved[int]` — the `int` possibility
+succeeds even though `list[int]` cannot. Only when no member can coerce does the coercion fail.
+
+Checks that require a concrete payload are deferred until the value resolves. For example,
+`unresolved[string]` narrows to `unresolved[int]` against an `int` target, but once resolved,
+the string must still parse as an integer. Similarly, any `unresolved[list[S]]` is accepted
+against any `list[U]` target, even when `S` has no coercion rule to `U`: the value could
+resolve to the empty list, which coerces to every list type, so element compatibility can
+only be checked once the payload is known. A source and target with no type-level coercion
+rule at all, such as `unresolved[list[int]]` against `int`, is rejected during validation.
+
+The two evaluation paths are deliberately asymmetric, and only in one direction. Type-level
+coercion may accept a pair that the concrete value later rejects, because the deciding
+information is a payload the placeholder does not carry. It must never reject a pair the
+concrete value would accept: doing so fails a template at validation time that would have run
+correctly, which no later stage can recover from. Any such case is a defect in the type-level
+rules, not a deliberate narrowing — the `range_expr` → `list[int]` and type-variable-target
+rules above apply identically on both paths for this reason.
 
 #### Method Call Coercion Restriction
 

--- a/rfcs/0005-expression-language.md
+++ b/rfcs/0005-expression-language.md
@@ -1508,8 +1508,8 @@ for operators with fixed signatures. The rules for propagating target types to c
 | `Compare` | All operands: `None` (unconstrained) |
 | `BinOp` | All operands: `None` (unconstrained) |
 | `UnaryOp` | Operand: `None` (unconstrained) |
-| `Call` (function) | Arguments: computed from candidate signatures |
-| `Call` (method) | Receiver: `None`, other args: computed from signatures |
+| `Call` (function) | Arguments: computed from candidate signatures' parameter types as written. A parameter type containing a type variable names a family of types (`list[T1]` is any list type), not one to coerce toward, so it leaves its position unconstrained; signature resolution still enforces it. The caller's target filters which signatures contribute; it is never bound through a signature's return type into its parameters. If no signature survives the filter, arguments are evaluated unconstrained (the target-type mismatch then surfaces as a coercion error on the call's result). |
+| `Call` (method) | Receiver: `None`, other args: `None` (unconstrained) |
 | `Subscript` | Value: `None`, index/slice: `{INT}` or `{INT?}` |
 | `List` | Elements: element type extracted from parent target types |
 | `ListComp` | Element expr: element type from parent, iter: `None`, conditions: `{BOOL}` |
@@ -1526,6 +1526,37 @@ For example, in `"{{ Param.Count - 1 }}"` where the target type is `{STRING}`:
 2. `1` is evaluated unconstrained → returns `int`
 3. `__sub__(int, int)` is called → returns `int`
 4. Result `int` is coerced to `string` for the target context
+
+The same principle governs function-call arguments. The caller's target
+describes the call's *result*, so it may select which signatures are
+plausible (by return type), but it must never alter how the arguments
+themselves evaluate beyond what the signatures' own parameter types say. In
+particular, for a generic signature such as `sorted(list: list[T1]) ->
+list[T1]`, the target is **not** unified with the return type to bind `T1`:
+`sorted([10, 2])` with target `{LIST[STRING]}` evaluates its argument
+unconstrained, sorts numerically, and coerces the *result* to
+`["2", "10"]`. Binding `T1 = string` into the argument would instead coerce
+the list first and sort lexicographically (`["10", "2"]`) — the target
+would have changed the computation, not just the type of its result.
+
+A parameter type containing a type variable constrains an argument to a
+family of types — `list[T1]` to any list type — which is not a type to
+coerce toward, so such positions are evaluated unconstrained. Signature
+resolution still enforces the constraint: `sorted("abc")` fails whether or
+not a target is supplied, and an argument a signature accepts by coercion
+(`range_expr` where `list[int]` is required) is still coerced there.
+
+**Signature resolution is independent of the target type.** Once arguments
+are evaluated, the implementation is selected by multiple dispatch over the
+argument types alone (see `resolve_and_call` below); a signature's return
+type never participates in resolution. The candidate filter above is a
+best-effort aid for evaluating arguments, not a resolution step: when no
+signature survives the filter, the arguments are evaluated unconstrained
+and the call is resolved and executed normally, with the target-type
+mismatch reported by the final result coercion. This ordering produces the
+more precise diagnostic — e.g. `min([1, 2])` with target `{LIST[STRING]}`
+reports that the `int` result cannot coerce to `list[string]`, rather than
+a generic "no matching signature" error.
 
 **Symbol Table**
 
@@ -1571,26 +1602,49 @@ def evaluate_expression(
                 # Evaluate operands without target type constraints
                 arg_values = [evaluate_expression(arg, None, symtabs) for arg in args]
             else:
-                # Regular function: find candidates and compute arg typesets
+                # Regular function: compute arg typesets from the signatures
+                # whose arity matches and whose return type is compatible
+                # with the caller's target. The target filters which
+                # signatures contribute — it is never unified with a
+                # signature's return type to bind type variables into the
+                # parameters.
                 candidates = [sig for sig in FUNCTION_SIGNATURES[func]
                               if len(sig.param_types) == len(args)
                                  and (ts is None or sig.return_type in ts
                                       or can_coerce(sig.return_type, ts))]
-                if not candidates:
-                    raise TypeError(f"No matching signature for {func}")
 
-                # Compute TypeSet for each argument position
+                # Compute TypeSet for each argument position from the
+                # parameter types as written. A symbolic parameter type
+                # (one containing a type variable) names a family of
+                # types rather than one to coerce toward — list[T1] means
+                # any list type — so it makes the position unconstrained;
+                # resolve_and_call still enforces it below. If no
+                # signature survived the filter, all positions are
+                # unconstrained: the call still resolves and executes
+                # normally, and the target-type mismatch surfaces as a
+                # coercion error on the call's result (a more precise
+                # diagnostic than failing here).
                 arg_typesets = []
                 for i in range(len(args)):
-                    arg_ts = {sig.param_types[i] for sig in candidates}
-                    arg_typesets.append(arg_ts)
+                    pos_types = {sig.param_types[i] for sig in candidates}
+                    if not pos_types or any(is_symbolic(t) for t in pos_types):
+                        arg_typesets.append(None)  # unconstrained
+                    else:
+                        arg_typesets.append(pos_types)
 
                 # Evaluate arguments with computed TypeSets
                 arg_values = [evaluate_expression(args[i], arg_typesets[i], symtabs)
                               for i in range(len(args))]
 
-            # Find best matching signature and call (coercion allowed on all args)
-            return resolve_and_call(func, arg_values, is_method_call=False)
+            # Find best matching signature and call (coercion allowed on
+            # all args). Resolution considers every arity-matching
+            # signature for the function — not just the target-filtered
+            # candidates above — and matches on argument types only:
+            # return types and the caller's target play no part in it.
+            all_sigs = [sig for sig in FUNCTION_SIGNATURES[func]
+                        if len(sig.param_types) == len(args)]
+            return resolve_and_call(func, all_sigs, arg_values,
+                                    is_method_call=False)
 
         case Call(Attribute(value, attr), args):
             # Method call: x.f(y, ...) -> f(x, y, ...)
@@ -1724,6 +1778,12 @@ def extract_element_typeset(ts: TypeSet) -> TypeSet:
     if ts is None:
         return None
     return {t.type_params[0] for t in ts if t.type_code == LIST}
+
+def is_symbolic(t: ExprType) -> bool:
+    # True if the type contains a type variable (T, T1, T2, T3),
+    # e.g. list[T1] in "sorted(list: list[T1]) -> list[T1]".
+    return t.type_code in (TYPEVAR_T, TYPEVAR_T1, TYPEVAR_T2, TYPEVAR_T3) \
+        or any(is_symbolic(p) for p in t.type_params)
 
 def can_coerce(from_type: ExprType, to_type: ExprType) -> bool:
     if from_type == to_type:

--- a/wiki/2026-02-Expression-Language.md
+++ b/wiki/2026-02-Expression-Language.md
@@ -920,6 +920,17 @@ by the calling context. The target type guides implicit type coercion (see
 must produce a value of type `T` or a type that can be implicitly coerced to `T`. When the
 target type is `T?`, the expression may also produce `None`/`null`.
 
+The target type is a statement about the expression's *result*: it guides
+which coercions are applied to values, but it never changes what the
+expression computes. Operands of operators, subscript receivers and indices,
+and function arguments are evaluated without inheriting the caller's target
+(see RFC 0005 §"Target Type Propagation Rules" for the per-node rules), and
+function overloads are selected by the argument types alone — a function's
+return type and the caller's target play no part in selecting the
+implementation. For example, `sorted([10, 2])` sorts numerically regardless
+of the target type; a `list[string]` target coerces the sorted result to
+`["2", "10"]` rather than coercing the input and sorting lexicographically.
+
 The expression language does not define how target types are determined — that is the
 responsibility of the embedding context. [Section 1.3.2](#132-evaluation-within-template-schemas)
 defines the target type rules for the [Template Schemas](2023-09-Template-Schemas).

--- a/wiki/2026-02-Expression-Language.md
+++ b/wiki/2026-02-Expression-Language.md
@@ -354,6 +354,19 @@ changes, so it is always safe to evaluate for type checking alone. Because parts
 that involve only concrete values are fully evaluated even when other parts are unresolved, this
 catches many errors during template validation — before parameter values are even selected.
 
+Target-type coercion applies the same conversion table to `unresolved[T]` values at the type
+level: the payload remains unresolved, but its constraint is narrowed to the coercion result
+(e.g. `unresolved[int]` against a `string` target becomes `unresolved[string]`). When the
+constraint is a union, coercion is existential: it succeeds if at least one member can coerce
+to the target, discarding the possibilities that cannot — `unresolved[int | list[int]]`
+against an `int` target yields `unresolved[int]`. Checks that require a concrete payload are
+deferred until the value resolves: `unresolved[string]` narrows to `unresolved[int]`, but the
+resolved string must still parse as an integer; likewise any `unresolved[list[S]]` is accepted
+against any `list[U]` target, since the value could resolve to the empty list, which coerces
+to every list type. Type-level coercion may therefore accept a
+pair that the concrete value later rejects, but it must never reject a pair the concrete value
+would accept — that would fail a template at validation time that would have run correctly.
+
 **Conditional Expressions with Unknown Conditions:**
 
 When the condition of an `if`/`else` expression evaluates to `unresolved[bool]`, the evaluator
@@ -841,7 +854,12 @@ coercion is performed where the intent is obvious. The following implicit conver
 - `int` → `float` when the target types do not include `int`
 - `path` → `string` when the target types do not include `path`
 - `range_expr` → `string` when the target types do not include `range_expr` (produces canonical form like `"1-5"`)
-- `range_expr` → `list[int]` when the target types include `list[int]` but not `range_expr`
+- `range_expr` → `list[int]` when the target types include `list[int]` but not `range_expr`.
+  This is the only list type a `range_expr` implicitly coerces to: a `list[T]` target with any
+  other element type (e.g. `list[float]` or `list[string]`) is an error. (A `list[any]` target
+  is also accepted, since a `list[int]` value already satisfies it.) Implicit rules do not
+  chain, so the materialized `list[int]` is not further widened element-wise. Use the explicit
+  conversion `list(r)` to get a `list[int]` value that the `list[T]` → `list[U]` rule then applies to.
 - `list[T]` → `list[U]` when each element `T` can be coerced to `U` (e.g., `list[path]` → `list[string]`)
 - `list[nulltype]` → `list[T]` for any `T` (empty list literal is compatible with any list type)
 - Any scalar value when the target types have a single scalar type. The value is coerced


### PR DESCRIPTION
This PR resolves two ambiguities in RFC 0005's expression-evaluation
pseudo-code that an implementation tripped over. It pins
both down in the direction the RFC's own design rationale points, and adds
matching language to the wiki's Expression Language page.

### Background

When a host evaluates an expression from a template, it passes a *target
type* — "whatever this expression computes, I need an `int` at the end."
RFC 0005's guiding rule for this is stated up front: target types guide
coercion, but must not constrain how sub-expressions evaluate. The target
describes the result, so a valid expression should compute the same thing
with or without one; the target only affects the type of what comes back.

The RFC's propagation table applies that rule node by node — operator
operands evaluate unconstrained, a ternary's branches inherit the target,
and so on. For function calls it says arguments get types "computed from
candidate signatures," backed by pseudo-code. That pseudo-code is where
the two ambiguities live. They were found while fixing target-type
propagation bugs in openjd-rs
(https://github.com/OpenJobDescription/openjd-rs/issues/291), when code
review pushed on what the correct call-argument behavior actually is and
the pseudo-code turned out not to fully answer the question.

### Ambiguity 1: do generic signatures bind the target into their arguments?

Take `sorted(list: list[T1]) -> list[T1]` evaluated as `sorted([10, 2])`
with target `list[string]`. Two readings:

- **Bind through the return type:** unify `list[string]` with the return
  type `list[T1]`, conclude `T1 = string`, and evaluate the argument
  toward `list[string]`. The list becomes `["10", "2"]` *before* sorting,
  and the sort is lexicographic: `["10", "2"]`.
- **Parameter types as written:** the argument's constraint is the
  literal `list[T1]` — any list type — so there is nothing to coerce
  toward. The sort is numeric, and the *result* coerces: `["2", "10"]`.

The pseudo-code computes `arg_ts = {sig.param_types[i] for sig in
candidates}` — parameter types as written, no unification step — but never
says so explicitly, and it doesn't say what a type-variable constraint
means for the argument. The first reading is tempting (the current Python
implementation exhibits it, though via a target-propagation bug rather
than by design), but it violates the RFC's own rule: the target changes
*what the expression computes* (which order the list is in), not just the
type of the result.

This PR makes the second reading explicit: argument typesets come from
parameter types as written, and the caller's target is never unified with
a return type to bind type variables into the parameters. A type-variable
parameter leaves its position unconstrained; the "any list" part is still
enforced during signature resolution, where `sorted("abc")` fails with or
without a target and a `range_expr` argument is still coerced to
`list[int]`.

### Ambiguity 2: does the target participate in overload resolution?

`resolve_and_call` is declared with a `candidates` parameter, and the
method-call arm passes one — but the function-call arm invokes it as
`resolve_and_call(func, arg_values, ...)`, with no candidates argument.
So the pseudo-code doesn't actually say whether final overload resolution
is restricted to the target-filtered candidate list or considers the
function's full signature set.

The related question with observable consequences: the function-call arm
raises "No matching signature" when the target filter leaves zero
candidates, even though the arguments might evaluate fine and the call
succeed — with only the final result failing to coerce. For `min([1, 2])`
with target `list[string]`, that's the difference between a generic
"No matching signature for min" and the precise "Cannot coerce int to
list[string]".

This PR pins both down: overload resolution matches argument types alone
against every arity-matching signature — return types and the caller's
target play no part in selecting the implementation — and an empty
candidate set falls back to evaluating arguments unconstrained rather
than raising, so target mismatches surface as precise result-coercion
errors. The empty-candidates change is the one place this PR amends
behavior rather than only clarifying it; flagging it for reviewers who
read the old `raise` as intentional.

### Changes

- **rfcs/0005-expression-language.md**
  - Propagation table: `Call (function)` row states the
    parameter-types-as-written rule, that a type-variable parameter type
    contributes no argument constraint (its concrete structure being
    enforced during resolution instead), and that the target filters
    candidates but never binds into parameters. `Call (method)` row
    corrected to
    "receiver: `None`, other args: `None`" — the old "computed from
    signatures" wording contradicted the RFC's own pseudo-code, which
    evaluates method arguments unconstrained.
  - Rationale: extends the existing `Param.Count - 1` example with the
    `sorted` case, and adds a "Signature resolution is independent of the
    target type" paragraph covering the dispatch and diagnostics rules.
  - Pseudo-code: the function-call arm no longer raises on empty
    candidates; symbolic/empty positions produce `None` (unconstrained)
    typesets via a new `is_symbolic` helper; `resolve_and_call` is
    invoked with an explicit all-arity-matching signature list, matching
    its declared parameters.
- **wiki/2026-02-Expression-Language.md** — §1.3.1 gains a paragraph
  stating the user-facing principle: the target describes the result,
  never the computation, with the `sorted` example.
- **conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-describes-result-not-computation.test.yaml**
  — new execution fixture pinning the clarified `Call` semantics through
  the one template context where a `list[string]` target is observable:
  bare `"{{expr}}"` `args` items (target `string? | list[string]` per
  §1.3.2). `sorted(Param.Ints)` on a `LIST[INT]` parameter must sort
  numerically and coerce/flatten the *result* (`2,10`), with the
  lexicographic order (`10,2`) asserted as forbidden output; the
  method-call form pins the receiver-unconstrained rule, and
  `min(Param.Ints)` pins that a call whose signatures' return types may
  not survive the target filter still resolves and executes normally.
  Complements the existing `expr1.3.1--target-type-propagation` fixture,
  which covers operator/ternary propagation but not calls.

No schema or template changes. openjd-rs implements
these semantics (and passes the new fixture) as of
OpenJobDescription/openjd-rs@c780846155668d16ad7bd0be3e732202797be4db, the
merged fix for OpenJobDescription/openjd-rs#291; the
Python implementation currently diverges on both points via the same
target-propagation bug tracked there.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
