### PR TITLE
fix: correct upper-Z EXPR conformance fixture

### DIFF
--- a/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-backslash-upper-Z.invalid.yaml
+++ b/conformance-tests/2023-09/EXPR/job_templates/expr2.2.5--re-backslash-upper-Z.invalid.yaml
@@ -10,4 +10,4 @@ steps:
         command: python
         args:
         - -c
-        - print(r'{{ re_search("hello", r"llo\z") }}')
+        - print(r'{{ re_search("hello", r"llo\Z") }}')


### PR DESCRIPTION
Closes #171

The upper-Z EXPR invalid fixture was byte-for-byte identical to the lower-z fixture and incorrectly exercised `\\z`. It now uses `\\Z`, so the conformance corpus tests the upper-case escape named by the file.

This change was prepared with AI assistance; the regression assertion was run locally and fails without the fix.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
