### PR TITLE
test: make single-task job fixtures assert their own output

### DIFF
--- a/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-merged-default-compatible.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-merged-default-compatible.test.yaml
@@ -18,43 +18,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["LEN:3", "SUM:6"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["LEN:3", "SUM:6"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-merged-default-compatible.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-merged-default-compatible.test.yaml
@@ -15,10 +15,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["LEN:3", "SUM:6"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'LEN:{{ len(Param.Values) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-supplied-value-within-constraints.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-supplied-value-within-constraints.test.yaml
@@ -16,10 +16,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["LEN:3", "SUM:15"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'LEN:{{ len(Param.Values) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-supplied-value-within-constraints.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.13--list-int-supplied-value-within-constraints.test.yaml
@@ -19,43 +19,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["LEN:3", "SUM:15"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["LEN:3", "SUM:15"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/2.16--list-list-int-param-runtime.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.16--list-list-int-param-runtime.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["LEN:3", "ROW0:[1, 2]", "ELEM:3", "FLAT:[1, 2, 3, 4, 5, 6]"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'LEN:{{ len(Param.Matrix) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/2.16--list-list-int-param-runtime.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.16--list-list-int-param-runtime.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["LEN:3", "ROW0:[1, 2]", "ELEM:3", "FLAT:[1, 2, 3, 4, 5, 6]"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["LEN:3", "ROW0:[1, 2]", "ELEM:3", "FLAT:[1, 2, 3, 4, 5, 6]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/2.9--bool-param-runtime.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.9--bool-param-runtime.test.yaml
@@ -13,10 +13,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["GPU:yes", "DEBUG:no", "NOT:true"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'GPU:{{ "yes" if Param.UseGpu else "no" }}')

--- a/conformance-tests/2023-09/EXPR/jobs/2.9--bool-param-runtime.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.9--bool-param-runtime.test.yaml
@@ -16,43 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["GPU:yes", "DEBUG:no", "NOT:true"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["GPU:yes", "DEBUG:no", "NOT:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-binding-with-param.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-binding-with-param.test.yaml
@@ -15,43 +15,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUT:10"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUT:10"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUT:{{ doubled }}')

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-binding-with-param.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-binding-with-param.test.yaml
@@ -12,10 +12,47 @@ template:
     let:
     - "doubled = Param.X * 2"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUT:10"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUT:{{ doubled }}')
 expected:

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-env-script-binding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-env-script-binding.test.yaml
@@ -20,43 +20,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["ENV:hello"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ENV:hello"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - import os; print('ENV:' + os.environ.get('GREETING', ''))

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-env-script-binding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-env-script-binding.test.yaml
@@ -17,10 +17,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["ENV:hello"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - import os; print('ENV:' + os.environ.get('GREETING', ''))
 expected:

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-in-host-requirements.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-in-host-requirements.test.yaml
@@ -20,43 +20,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["GPU:1"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["GPU:1"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-in-host-requirements.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-in-host-requirements.test.yaml
@@ -17,10 +17,47 @@ template:
       - name: amount.worker.gpu
         min: "{{ gpu_count }}"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["GPU:1"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'GPU:{{ gpu_count }}')

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-scopes.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-scopes.test.yaml
@@ -10,10 +10,47 @@ template:
     script:
       let:
       - "script_val = 20"
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["STEP:10", "SCRIPT:20", "SUM:30"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'STEP:{{ step_val }}')

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-scopes.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-scopes.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["STEP:10", "SCRIPT:20", "SUM:30"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["STEP:10", "SCRIPT:20", "SUM:30"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-script-binding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-script-binding.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["X:1", "Y:2", "Z:6"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["X:1", "Y:2", "Z:6"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-script-binding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-script-binding.test.yaml
@@ -10,10 +10,47 @@ template:
       - "x = 1"
       - "y = x + 1"
       - "z = y * 3"
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["X:1", "Y:2", "Z:6"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'X:{{ x }}')

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-step-binding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-step-binding.test.yaml
@@ -9,10 +9,47 @@ template:
     - "base = 100"
     - "doubled = base * 2"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["BASE:100", "DOUBLED:200"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'BASE:{{ base }}')

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-step-binding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-step-binding.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["BASE:100", "DOUBLED:200"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["BASE:100", "DOUBLED:200"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-step-env-binding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-step-env-binding.test.yaml
@@ -22,43 +22,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MSG:HELLO_WORLD"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MSG:HELLO_WORLD"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - import os; print('MSG:' + os.environ.get('MSG', ''))

--- a/conformance-tests/2023-09/EXPR/jobs/3.6--let-step-env-binding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/3.6--let-step-env-binding.test.yaml
@@ -19,10 +19,47 @@ template:
             - -c
             - "print('openjd_env: MSG={{ combined }}')"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MSG:HELLO_WORLD"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - import os; print('MSG:' + os.environ.get('MSG', ''))
 expected:

--- a/conformance-tests/2023-09/EXPR/jobs/7.3--host-context-symbols.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/7.3--host-context-symbols.test.yaml
@@ -9,49 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "WD_LEN:true",
-              "WD_IS_PATH:true",
-              "HAS_PM:false",
-              "HAS_PM_COND:no",
-              "PM_FILE_IS_PATH:.json",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["WD_LEN:true", "WD_IS_PATH:true", "HAS_PM:false", "HAS_PM_COND:no", "PM_FILE_IS_PATH:.json"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/7.3--host-context-symbols.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/7.3--host-context-symbols.test.yaml
@@ -6,10 +6,53 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "WD_LEN:true",
+              "WD_IS_PATH:true",
+              "HAS_PM:false",
+              "HAS_PM_COND:no",
+              "PM_FILE_IS_PATH:.json",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'WD_LEN:{{ len(string(Session.WorkingDirectory)) > 0 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/7.3--task-file-expr-properties.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/7.3--task-file-expr-properties.test.yaml
@@ -13,38 +13,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["EXISTS:True", "CONTENT:greeting=hello", "HAS_PARENT:true"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["EXISTS:True", "CONTENT:greeting=hello", "HAS_PARENT:true"]}
       - name: config
         type: TEXT
         data: "greeting={{Param.Greeting}}"
@@ -56,6 +29,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/7.3--task-file-expr-properties.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/7.3--task-file-expr-properties.test.yaml
@@ -11,6 +11,40 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["EXISTS:True", "CONTENT:greeting=hello", "HAS_PARENT:true"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: config
         type: TEXT
         data: "greeting={{Param.Greeting}}"
@@ -21,6 +55,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             import os

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.1.3--keyword-attrs-in-exprs.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.1.3--keyword-attrs-in-exprs.test.yaml
@@ -129,10 +129,89 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "False:v_False",
+              "None:v_None",
+              "True:v_True",
+              "and:v_and",
+              "as:v_as",
+              "assert:v_assert",
+              "async:v_async",
+              "await:v_await",
+              "break:v_break",
+              "class:v_class",
+              "continue:v_continue",
+              "def:v_def",
+              "del:v_del",
+              "elif:v_elif",
+              "else:v_else",
+              "except:v_except",
+              "finally:v_finally",
+              "for:v_for",
+              "from:v_from",
+              "global:v_global",
+              "if:v_if",
+              "import:v_import",
+              "in:v_in",
+              "is:v_is",
+              "lambda:v_lambda",
+              "nonlocal:v_nonlocal",
+              "not:v_not",
+              "or:v_or",
+              "pass:v_pass",
+              "raise:v_raise",
+              "return:v_return",
+              "try:v_try",
+              "while:v_while",
+              "with:v_with",
+              "yield:v_yield",
+              "_:v__",
+              "case:v_case",
+              "match:v_match",
+              "type:v_type",
+              "COND:v_if",
+              "LOGIC:v_and",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'False:{{ Param.False }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.1.3--keyword-attrs-in-exprs.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.1.3--keyword-attrs-in-exprs.test.yaml
@@ -132,85 +132,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "False:v_False",
-              "None:v_None",
-              "True:v_True",
-              "and:v_and",
-              "as:v_as",
-              "assert:v_assert",
-              "async:v_async",
-              "await:v_await",
-              "break:v_break",
-              "class:v_class",
-              "continue:v_continue",
-              "def:v_def",
-              "del:v_del",
-              "elif:v_elif",
-              "else:v_else",
-              "except:v_except",
-              "finally:v_finally",
-              "for:v_for",
-              "from:v_from",
-              "global:v_global",
-              "if:v_if",
-              "import:v_import",
-              "in:v_in",
-              "is:v_is",
-              "lambda:v_lambda",
-              "nonlocal:v_nonlocal",
-              "not:v_not",
-              "or:v_or",
-              "pass:v_pass",
-              "raise:v_raise",
-              "return:v_return",
-              "try:v_try",
-              "while:v_while",
-              "with:v_with",
-              "yield:v_yield",
-              "_:v__",
-              "case:v_case",
-              "match:v_match",
-              "type:v_type",
-              "COND:v_if",
-              "LOGIC:v_and",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["False:v_False", "None:v_None", "True:v_True", "and:v_and", "as:v_as", "assert:v_assert", "async:v_async", "await:v_await", "break:v_break", "class:v_class", "continue:v_continue", "def:v_def", "del:v_del", "elif:v_elif", "else:v_else", "except:v_except", "finally:v_finally", "for:v_for", "from:v_from", "global:v_global", "if:v_if", "import:v_import", "in:v_in", "is:v_is", "lambda:v_lambda", "nonlocal:v_nonlocal", "not:v_not", "or:v_or", "pass:v_pass", "raise:v_raise", "return:v_return", "try:v_try", "while:v_while", "with:v_with", "yield:v_yield", "_:v__", "case:v_case", "match:v_match", "type:v_type", "COND:v_if", "LOGIC:v_and"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.1.5--string-literals.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.1.5--string-literals.test.yaml
@@ -11,10 +11,62 @@ template:
     - "rtdq = r\"\"\"raw\\ntriple\"\"\""
     - "rtsq = r'''raw\\ntriple'''"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "DQ:5",
+              "SQ:5",
+              "RDQ:hello\\n",
+              "RSQ:hello\\n",
+              "RDQ_LEN:7",
+              "RSQ_LEN:7",
+              "ESC_LEN:11",
+              "ESC_T_LEN:3",
+              "ESC_BS:a\\b",
+              "RAW_BS:C:\\Users\\test",
+              "TDQ_LEN:13",
+              "TSQ_LEN:13",
+              "RTDQ:raw\\ntriple",
+              "RTSQ:raw\\ntriple",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'DQ:{{ len("hello") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.1.5--string-literals.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.1.5--string-literals.test.yaml
@@ -14,58 +14,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "DQ:5",
-              "SQ:5",
-              "RDQ:hello\\n",
-              "RSQ:hello\\n",
-              "RDQ_LEN:7",
-              "RSQ_LEN:7",
-              "ESC_LEN:11",
-              "ESC_T_LEN:3",
-              "ESC_BS:a\\b",
-              "RAW_BS:C:\\Users\\test",
-              "TDQ_LEN:13",
-              "TSQ_LEN:13",
-              "RTDQ:raw\\ntriple",
-              "RTSQ:raw\\ntriple",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["DQ:5", "SQ:5", "RDQ:hello\\n", "RSQ:hello\\n", "RDQ_LEN:7", "RSQ_LEN:7", "ESC_LEN:11", "ESC_T_LEN:3", "ESC_BS:a\\b", "RAW_BS:C:\\Users\\test", "TDQ_LEN:13", "TSQ_LEN:13", "RTDQ:raw\\ntriple", "RTSQ:raw\\ntriple"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.1.6--numeric-literals.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.1.6--numeric-literals.test.yaml
@@ -9,56 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "HEX:42",
-              "OCT:42",
-              "BIN:42",
-              "USCORE:1000000",
-              "SCI_PASS:1.5e3",
-              "SCI_NEG_PASS:1.5e-3",
-              "SCI_ADD:1500.0",
-              "SCI_NEG_ADD:0.0015",
-              "SCI_POS:1500.0",
-              "SCI_NEG_POS:0.0015",
-              "HEX_US:65535",
-              "BIN_US:170",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["HEX:42", "OCT:42", "BIN:42", "USCORE:1000000", "SCI_PASS:1.5e3", "SCI_NEG_PASS:1.5e-3", "SCI_ADD:1500.0", "SCI_NEG_ADD:0.0015", "SCI_POS:1500.0", "SCI_NEG_POS:0.0015", "HEX_US:65535", "BIN_US:170"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.1.6--numeric-literals.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.1.6--numeric-literals.test.yaml
@@ -6,10 +6,60 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "HEX:42",
+              "OCT:42",
+              "BIN:42",
+              "USCORE:1000000",
+              "SCI_PASS:1.5e3",
+              "SCI_NEG_PASS:1.5e-3",
+              "SCI_ADD:1500.0",
+              "SCI_NEG_ADD:0.0015",
+              "SCI_POS:1500.0",
+              "SCI_NEG_POS:0.0015",
+              "HEX_US:65535",
+              "BIN_US:170",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'HEX:{{ 0x2A }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.1.7--multiline.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.1.7--multiline.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["ARITH:6", "COND:high", "COMP:[4, 6]"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ARITH:6", "COND:high", "COMP:[4, 6]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.1.7--multiline.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.1.7--multiline.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["ARITH:6", "COND:high", "COMP:[4, 6]"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'ARITH:{{ 1 +

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.3--implicit-coercion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.3--implicit-coercion.test.yaml
@@ -13,54 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "INTFLOAT:3.5",
-              "PATHSTR:true",
-              "RANGECAT:[10, 20, 1, 2, 3]",
-              "RANGE_STR:1-3",
-              "RANGE_FMT:frames=1-3",
-              "RANGE_ADD:frames: 1-3",
-              "RANGE_ADD2:1-3 are frames",
-              "FMT_EMBED:Count is 3 items",
-              "BOOL_FMT:val=true",
-              "LIST_PATH_STR:/a,/b",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INTFLOAT:3.5", "PATHSTR:true", "RANGECAT:[10, 20, 1, 2, 3]", "RANGE_STR:1-3", "RANGE_FMT:frames=1-3", "RANGE_ADD:frames: 1-3", "RANGE_ADD2:1-3 are frames", "FMT_EMBED:Count is 3 items", "BOOL_FMT:val=true", "LIST_PATH_STR:/a,/b"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.3--implicit-coercion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.3--implicit-coercion.test.yaml
@@ -10,10 +10,58 @@ template:
     - 'path_join = [path("/a"), path("/b")].join(",")'
     - 'path_sw = startswith(path("/mnt/out"), "/mnt")'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "INTFLOAT:3.5",
+              "PATHSTR:true",
+              "RANGECAT:[10, 20, 1, 2, 3]",
+              "RANGE_STR:1-3",
+              "RANGE_FMT:frames=1-3",
+              "RANGE_ADD:frames: 1-3",
+              "RANGE_ADD2:1-3 are frames",
+              "FMT_EMBED:Count is 3 items",
+              "BOOL_FMT:val=true",
+              "LIST_PATH_STR:/a,/b",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INTFLOAT:{{ 2 + 1.5 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.4--function-vs-method-coercion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.4--function-vs-method-coercion.test.yaml
@@ -12,57 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "FUNC_COERCE:true",
-              "METHOD_OK:true",
-              "HOST_METHOD:true",
-              "HOST_FUNC:true",
-              "HOST_FUNC_WIN:false",
-          ]
-          EXPECTED_WINDOWS = [
-              "FUNC_COERCE:true",
-              "METHOD_OK:true",
-              "HOST_METHOD:true",
-              "HOST_FUNC:false",
-              "HOST_FUNC_WIN:true",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["FUNC_COERCE:true", "METHOD_OK:true", "HOST_METHOD:true", "HOST_FUNC:true", "HOST_FUNC_WIN:false"], "expected_windows": ["FUNC_COERCE:true", "METHOD_OK:true", "HOST_METHOD:true", "HOST_FUNC:false", "HOST_FUNC_WIN:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.4--function-vs-method-coercion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.4--function-vs-method-coercion.test.yaml
@@ -9,10 +9,61 @@ template:
     - 'func_coerce = startswith(path("/foo/bar"), "/foo")'
     - 'method_ok = "/foo/bar".startswith("/foo")'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "FUNC_COERCE:true",
+              "METHOD_OK:true",
+              "HOST_METHOD:true",
+              "HOST_FUNC:true",
+              "HOST_FUNC_WIN:false",
+          ]
+          EXPECTED_WINDOWS = [
+              "FUNC_COERCE:true",
+              "METHOD_OK:true",
+              "HOST_METHOD:true",
+              "HOST_FUNC:false",
+              "HOST_FUNC_WIN:true",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'FUNC_COERCE:{{ func_coerce }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.5--cross-type-equality.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.5--cross-type-equality.test.yaml
@@ -8,10 +8,77 @@ template:
     let:
     - 'r = range_expr("1-3")'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "LIST_RANGE:true",
+              "RANGE_LIST:true",
+              "SCALAR_LIST:false",
+              "ELEM_CROSS:true",
+              "NESTED_CROSS:true",
+              "BOOL_INT:false",
+              "BOOL_STR:false",
+              "STR_INT:false",
+              "NULL_ZERO:false",
+              "NULL_NULL:true",
+              "LIST_DIFF_LEN:false",
+              "STR_PATH:true",
+              "PATH_STR:true",
+          ]
+          EXPECTED_WINDOWS = [
+              "LIST_RANGE:true",
+              "RANGE_LIST:true",
+              "SCALAR_LIST:false",
+              "ELEM_CROSS:true",
+              "NESTED_CROSS:true",
+              "BOOL_INT:false",
+              "BOOL_STR:false",
+              "STR_INT:false",
+              "NULL_ZERO:false",
+              "NULL_NULL:true",
+              "LIST_DIFF_LEN:false",
+              "STR_PATH:false",
+              "PATH_STR:false",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'LIST_RANGE:{{ [1, 2, 3] == range_expr("1-3") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.5--cross-type-equality.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.5--cross-type-equality.test.yaml
@@ -11,73 +11,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "LIST_RANGE:true",
-              "RANGE_LIST:true",
-              "SCALAR_LIST:false",
-              "ELEM_CROSS:true",
-              "NESTED_CROSS:true",
-              "BOOL_INT:false",
-              "BOOL_STR:false",
-              "STR_INT:false",
-              "NULL_ZERO:false",
-              "NULL_NULL:true",
-              "LIST_DIFF_LEN:false",
-              "STR_PATH:true",
-              "PATH_STR:true",
-          ]
-          EXPECTED_WINDOWS = [
-              "LIST_RANGE:true",
-              "RANGE_LIST:true",
-              "SCALAR_LIST:false",
-              "ELEM_CROSS:true",
-              "NESTED_CROSS:true",
-              "BOOL_INT:false",
-              "BOOL_STR:false",
-              "STR_INT:false",
-              "NULL_ZERO:false",
-              "NULL_NULL:true",
-              "LIST_DIFF_LEN:false",
-              "STR_PATH:false",
-              "PATH_STR:false",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["LIST_RANGE:true", "RANGE_LIST:true", "SCALAR_LIST:false", "ELEM_CROSS:true", "NESTED_CROSS:true", "BOOL_INT:false", "BOOL_STR:false", "STR_INT:false", "NULL_ZERO:false", "NULL_NULL:true", "LIST_DIFF_LEN:false", "STR_PATH:true", "PATH_STR:true"], "expected_windows": ["LIST_RANGE:true", "RANGE_LIST:true", "SCALAR_LIST:false", "ELEM_CROSS:true", "NESTED_CROSS:true", "BOOL_INT:false", "BOOL_STR:false", "STR_INT:false", "NULL_ZERO:false", "NULL_NULL:true", "LIST_DIFF_LEN:false", "STR_PATH:false", "PATH_STR:false"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.6--list-type-inference.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.6--list-type-inference.test.yaml
@@ -23,10 +23,77 @@ template:
     - 'nested_mix_int_float = [[1], [2.0]]'
     - 'nested_mix_path_str = [[path("/a")], ["b"]]'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "HOMO_INT:[1, 2, 3]",
+              "HOMO_FLOAT:[1.0, 2.0]",
+              "HOMO_STR:[\"a\", \"b\"]",
+              "MIX_INT_FLOAT:[1.0, 2.0]",
+              "MIX_PATH_STR:[\"/a\", \"b\"]",
+              "EMPTY:[]",
+              "NESTED_INT:[[1, 2], [3, 4]]",
+              "NESTED_FLOAT:[[1.0, 2.0], [3.0, 4.0]]",
+              "NESTED_STR:[[\"a\", \"b\"], [\"c\"]]",
+              "NESTED_MIX_INT_FLOAT:[[1.0], [2.0]]",
+              "NESTED_MIX_PATH_STR:[[\"/a\"], [\"b\"]]",
+              "HOMO_PATH:[\"/a\", \"/b\"]",
+              "NESTED_PATH:[[\"/a\"], [\"/b\"]]",
+          ]
+          EXPECTED_WINDOWS = [
+              "HOMO_INT:[1, 2, 3]",
+              "HOMO_FLOAT:[1.0, 2.0]",
+              "HOMO_STR:[\"a\", \"b\"]",
+              "MIX_INT_FLOAT:[1.0, 2.0]",
+              "MIX_PATH_STR:[\"/a\", \"b\"]",
+              "EMPTY:[]",
+              "NESTED_INT:[[1, 2], [3, 4]]",
+              "NESTED_FLOAT:[[1.0, 2.0], [3.0, 4.0]]",
+              "NESTED_STR:[[\"a\", \"b\"], [\"c\"]]",
+              "NESTED_MIX_INT_FLOAT:[[1.0], [2.0]]",
+              "NESTED_MIX_PATH_STR:[[\"/a\"], [\"b\"]]",
+              "HOMO_PATH:[\"\\a\", \"\\b\"]",
+              "NESTED_PATH:[[\"\\a\"], [\"\\b\"]]",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'HOMO_INT:{{ homo_int }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.6--list-type-inference.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.6--list-type-inference.test.yaml
@@ -26,73 +26,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "HOMO_INT:[1, 2, 3]",
-              "HOMO_FLOAT:[1.0, 2.0]",
-              "HOMO_STR:[\"a\", \"b\"]",
-              "MIX_INT_FLOAT:[1.0, 2.0]",
-              "MIX_PATH_STR:[\"/a\", \"b\"]",
-              "EMPTY:[]",
-              "NESTED_INT:[[1, 2], [3, 4]]",
-              "NESTED_FLOAT:[[1.0, 2.0], [3.0, 4.0]]",
-              "NESTED_STR:[[\"a\", \"b\"], [\"c\"]]",
-              "NESTED_MIX_INT_FLOAT:[[1.0], [2.0]]",
-              "NESTED_MIX_PATH_STR:[[\"/a\"], [\"b\"]]",
-              "HOMO_PATH:[\"/a\", \"/b\"]",
-              "NESTED_PATH:[[\"/a\"], [\"/b\"]]",
-          ]
-          EXPECTED_WINDOWS = [
-              "HOMO_INT:[1, 2, 3]",
-              "HOMO_FLOAT:[1.0, 2.0]",
-              "HOMO_STR:[\"a\", \"b\"]",
-              "MIX_INT_FLOAT:[1.0, 2.0]",
-              "MIX_PATH_STR:[\"/a\", \"b\"]",
-              "EMPTY:[]",
-              "NESTED_INT:[[1, 2], [3, 4]]",
-              "NESTED_FLOAT:[[1.0, 2.0], [3.0, 4.0]]",
-              "NESTED_STR:[[\"a\", \"b\"], [\"c\"]]",
-              "NESTED_MIX_INT_FLOAT:[[1.0], [2.0]]",
-              "NESTED_MIX_PATH_STR:[[\"/a\"], [\"b\"]]",
-              "HOMO_PATH:[\"\\a\", \"\\b\"]",
-              "NESTED_PATH:[[\"\\a\"], [\"\\b\"]]",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["HOMO_INT:[1, 2, 3]", "HOMO_FLOAT:[1.0, 2.0]", "HOMO_STR:[\"a\", \"b\"]", "MIX_INT_FLOAT:[1.0, 2.0]", "MIX_PATH_STR:[\"/a\", \"b\"]", "EMPTY:[]", "NESTED_INT:[[1, 2], [3, 4]]", "NESTED_FLOAT:[[1.0, 2.0], [3.0, 4.0]]", "NESTED_STR:[[\"a\", \"b\"], [\"c\"]]", "NESTED_MIX_INT_FLOAT:[[1.0], [2.0]]", "NESTED_MIX_PATH_STR:[[\"/a\"], [\"b\"]]", "HOMO_PATH:[\"/a\", \"/b\"]", "NESTED_PATH:[[\"/a\"], [\"/b\"]]"], "expected_windows": ["HOMO_INT:[1, 2, 3]", "HOMO_FLOAT:[1.0, 2.0]", "HOMO_STR:[\"a\", \"b\"]", "MIX_INT_FLOAT:[1.0, 2.0]", "MIX_PATH_STR:[\"/a\", \"b\"]", "EMPTY:[]", "NESTED_INT:[[1, 2], [3, 4]]", "NESTED_FLOAT:[[1.0, 2.0], [3.0, 4.0]]", "NESTED_STR:[[\"a\", \"b\"], [\"c\"]]", "NESTED_MIX_INT_FLOAT:[[1.0], [2.0]]", "NESTED_MIX_PATH_STR:[[\"/a\"], [\"b\"]]", "HOMO_PATH:[\"\\a\", \"\\b\"]", "NESTED_PATH:[[\"\\a\"], [\"\\b\"]]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-describes-result-not-computation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-describes-result-not-computation.test.yaml
@@ -27,43 +27,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["ARGS:2,10,SEP,2,10,SEP,2"]
-          FORBIDDEN = ["ARGS:10,2"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ARGS:2,10,SEP,2,10,SEP,2"], "forbidden": ["ARGS:10,2"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-describes-result-not-computation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-describes-result-not-computation.test.yaml
@@ -24,10 +24,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["ARGS:2,10,SEP,2,10,SEP,2"]
+          FORBIDDEN = ["ARGS:10,2"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             import sys

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-type-propagation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-type-propagation.test.yaml
@@ -27,10 +27,57 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "BINOP_SUB:9",
+              "BINOP_MUL:20",
+              "BINOP_DIV:2.5",
+              "UNARY_NEG:-10",
+              "UNARY_NOT:false",
+              "CMP_GT:true",
+              "CMP_LE:true",
+              "IFEXP:big",
+              "CHAIN:over",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             # BinOp operands must keep their numeric types

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-type-propagation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.1--target-type-propagation.test.yaml
@@ -30,53 +30,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "BINOP_SUB:9",
-              "BINOP_MUL:20",
-              "BINOP_DIV:2.5",
-              "UNARY_NEG:-10",
-              "UNARY_NOT:false",
-              "CMP_GT:true",
-              "CMP_LE:true",
-              "IFEXP:big",
-              "CHAIN:over",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["BINOP_SUB:9", "BINOP_MUL:20", "BINOP_DIV:2.5", "UNARY_NEG:-10", "UNARY_NOT:false", "CMP_GT:true", "CMP_LE:true", "IFEXP:big", "CHAIN:over"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.10--string-path-operation-counting.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.10--string-path-operation-counting.test.yaml
@@ -20,10 +20,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:117600"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - "print(r'RESULT:{{ len([len((\"a\" * 10000).upper()) for i in range(117600)]) }}')"
 expected:

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.10--string-path-operation-counting.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.10--string-path-operation-counting.test.yaml
@@ -23,43 +23,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:117600"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:117600"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - "print(r'RESULT:{{ len([len((\"a\" * 10000).upper()) for i in range(117600)]) }}')"

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--format-string-semantics.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--format-string-semantics.test.yaml
@@ -13,45 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "ARGS:--input file.exr --verbose --quality 90 'prefix 42 suffix' 'list: [1, 2, 3]' null:end",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ARGS:--input file.exr --verbose --quality 90 'prefix 42 suffix' 'list: [1, 2, 3]' null:end"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--format-string-semantics.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--format-string-semantics.test.yaml
@@ -10,10 +10,49 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "ARGS:--input file.exr --verbose --quality 90 'prefix 42 suffix' 'list: [1, 2, 3]' null:end",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             import shlex, sys

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--list-flattens-in-args.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--list-flattens-in-args.test.yaml
@@ -18,10 +18,59 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "ARG0:--width",
+              "ARG1:1920",
+              "ARG2:--height",
+              "ARG3:1080",
+              "ARG4:--verbose",
+              "ARG5:--color",
+              "ARG6:--single",
+              "ARG7:--debug",
+              "ARG8:on",
+              "ARG9:--end",
+              "COUNT:10",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             import sys

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--list-flattens-in-args.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--list-flattens-in-args.test.yaml
@@ -21,55 +21,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "ARG0:--width",
-              "ARG1:1920",
-              "ARG2:--height",
-              "ARG3:1080",
-              "ARG4:--verbose",
-              "ARG5:--color",
-              "ARG6:--single",
-              "ARG7:--debug",
-              "ARG8:on",
-              "ARG9:--end",
-              "COUNT:10",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ARG0:--width", "ARG1:1920", "ARG2:--height", "ARG3:1080", "ARG4:--verbose", "ARG5:--color", "ARG6:--single", "ARG7:--debug", "ARG8:on", "ARG9:--end", "COUNT:10"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--null-skips-arg.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--null-skips-arg.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["ARGS:--input file.exr"]
-          FORBIDDEN = ["--verbose", "--quality"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ARGS:--input file.exr"], "forbidden": ["--verbose", "--quality"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--null-skips-arg.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--null-skips-arg.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["ARGS:--input file.exr"]
+          FORBIDDEN = ["--verbose", "--quality"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             import sys

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--scalar-string-coercion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--scalar-string-coercion.test.yaml
@@ -20,10 +20,54 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "BOOL_PARAM:true",
+              "BOOL_FALSE:false",
+              "BOOL_LITERAL:true",
+              "NEGATION:false",
+              "NULL:[]",
+              "FLOAT:1.50",
+          ]
+          FORBIDDEN = ["BOOL_PARAM:True", "BOOL_FALSE:False", "NULL:[None]", "NULL:[null]"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'BOOL_PARAM:{{ Param.Enabled }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--scalar-string-coercion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.2--scalar-string-coercion.test.yaml
@@ -23,50 +23,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "BOOL_PARAM:true",
-              "BOOL_FALSE:false",
-              "BOOL_LITERAL:true",
-              "NEGATION:false",
-              "NULL:[]",
-              "FLOAT:1.50",
-          ]
-          FORBIDDEN = ["BOOL_PARAM:True", "BOOL_FALSE:False", "NULL:[None]", "NULL:[null]"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["BOOL_PARAM:true", "BOOL_FALSE:false", "BOOL_LITERAL:true", "NEGATION:false", "NULL:[]", "FLOAT:1.50"], "forbidden": ["BOOL_PARAM:True", "BOOL_FALSE:False", "NULL:[None]", "NULL:[null]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.3--ufcs.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.3--ufcs.test.yaml
@@ -14,10 +14,47 @@ template:
     - 'file = path("/projects/shot01/render.exr")'
     - 'prop = file.stem'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["FUNC:HELLO", "METHOD:HELLO", "CHAINED:a;b;c", "PROP:render"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'FUNC:{{ func_upper }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.3--ufcs.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.3--ufcs.test.yaml
@@ -17,43 +17,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["FUNC:HELLO", "METHOD:HELLO", "CHAINED:a;b;c", "PROP:render"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["FUNC:HELLO", "METHOD:HELLO", "CHAINED:a;b;c", "PROP:render"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.4--float-passthrough.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.4--float-passthrough.test.yaml
@@ -16,50 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "PARAM:3.500",
-              "PARAM_CALC:4.5",
-              "LET:1.30",
-              "LIST_IDX:1.70",
-              "IF_TRUE:3.500",
-              "IF_FALSE:3.500",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["PARAM:3.500", "PARAM_CALC:4.5", "LET:1.30", "LIST_IDX:1.70", "IF_TRUE:3.500", "IF_FALSE:3.500"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.4--float-passthrough.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.4--float-passthrough.test.yaml
@@ -13,10 +13,54 @@ template:
     - "from_let = 1.30"
     - "from_list = [1.70]"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "PARAM:3.500",
+              "PARAM_CALC:4.5",
+              "LET:1.30",
+              "LIST_IDX:1.70",
+              "IF_TRUE:3.500",
+              "IF_FALSE:3.500",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'PARAM:{{Param.V}}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.4--negative-zero.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.4--negative-zero.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["NEG_ZERO:0.0", "NEG_MUL:0.0", "ABS:0.0", "EQ:true"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["NEG_ZERO:0.0", "NEG_MUL:0.0", "ABS:0.0", "EQ:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.4--negative-zero.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.4--negative-zero.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["NEG_ZERO:0.0", "NEG_MUL:0.0", "ABS:0.0", "EQ:true"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'NEG_ZERO:{{ -0.0 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.5--conditionals.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.5--conditionals.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["TRUE:yes", "FALSE:no", "CALC:20"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'TRUE:{{ "yes" if Param.Flag else "no" }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.5--conditionals.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.5--conditionals.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["TRUE:yes", "FALSE:no", "CALC:20"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["TRUE:yes", "FALSE:no", "CALC:20"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.7--comprehensions.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.7--comprehensions.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["BASIC:[2, 4, 6]", "FILTER:[3, 4, 5]", "RANGE:[10, 20, 30, 40, 50]"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["BASIC:[2, 4, 6]", "FILTER:[3, 4, 5]", "RANGE:[10, 20, 30, 40, 50]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.7--comprehensions.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.7--comprehensions.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["BASIC:[2, 4, 6]", "FILTER:[3, 4, 5]", "RANGE:[10, 20, 30, 40, 50]"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'BASIC:{{ [x * 2 for x in [1, 2, 3]] }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.7--loop-var-valid.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.7--loop-var-valid.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["LOWER:[2, 4, 6]", "UNDER:[11, 21]"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["LOWER:[2, 4, 6]", "UNDER:[11, 21]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.7--loop-var-valid.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.7--loop-var-valid.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["LOWER:[2, 4, 6]", "UNDER:[11, 21]"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'LOWER:{{ [x * 2 for x in [1, 2, 3]] }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.8--slice-edge-cases.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.8--slice-edge-cases.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["CLAMP:[1, 2, 3]", "NEG_STEP:[5, 4, 3]", "NEG_FULL:dcb"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["CLAMP:[1, 2, 3]", "NEG_STEP:[5, 4, 3]", "NEG_FULL:dcb"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.3.8--slice-edge-cases.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.3.8--slice-edge-cases.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["CLAMP:[1, 2, 3]", "NEG_STEP:[5, 4, 3]", "NEG_FULL:dcb"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'CLAMP:{{ [1, 2, 3][0:100] }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--division.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--division.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["TRUEDIV:3.5", "FLOORDIV:3", "EXACT:3.0", "FFLOORDIV:3"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'TRUEDIV:{{ 7 / 2 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--division.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--division.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["TRUEDIV:3.5", "FLOORDIV:3", "EXACT:3.0", "FFLOORDIV:3"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["TRUEDIV:3.5", "FLOORDIV:3", "EXACT:3.0", "FFLOORDIV:3"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--exponentiation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--exponentiation.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["POSEXP:8", "NEGEXP:0.125", "FEXP:8.0", "ZEROEXP:1", "ZEROF:1.0"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'POSEXP:{{ 2 ** 3 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--exponentiation.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--exponentiation.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["POSEXP:8", "NEGEXP:0.125", "FEXP:8.0", "ZEROEXP:1", "ZEROF:1.0"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["POSEXP:8", "NEGEXP:0.125", "FEXP:8.0", "ZEROEXP:1", "ZEROF:1.0"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--float-arithmetic.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--float-arithmetic.test.yaml
@@ -16,43 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["FADD:4.0", "PROMOTE:3.5", "FSUB:3.5", "FMUL:3.0", "FMOD:1.5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["FADD:4.0", "PROMOTE:3.5", "FSUB:3.5", "FMUL:3.0", "FMOD:1.5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--float-arithmetic.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--float-arithmetic.test.yaml
@@ -13,10 +13,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["FADD:4.0", "PROMOTE:3.5", "FSUB:3.5", "FMUL:3.0", "FMOD:1.5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'FADD:{{ 1.5 + 2.5 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int-arithmetic.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int-arithmetic.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["ADD:13", "SUB:7", "MUL:30", "FLOORDIV:3", "MOD:1", "NEG:-10", "POS:10"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ADD:13", "SUB:7", "MUL:30", "FLOORDIV:3", "MOD:1", "NEG:-10", "POS:10"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int-arithmetic.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int-arithmetic.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["ADD:13", "SUB:7", "MUL:30", "FLOORDIV:3", "MOD:1", "NEG:-10", "POS:10"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'ADD:{{ Param.X + 3 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int64-bounds.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int64-bounds.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MIN:-9223372036854775808", "MAX:9223372036854775807", "SUM:-1"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'MIN:{{ -9223372036854775808 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int64-bounds.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int64-bounds.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MIN:-9223372036854775808", "MAX:9223372036854775807", "SUM:-1"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MIN:-9223372036854775808", "MAX:9223372036854775807", "SUM:-1"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int64-float-large.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int64-float-large.test.yaml
@@ -7,10 +7,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["POS:9223372036854775808.0", "NEG:-9.223372036854776e+18"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'POS:{{ 9223372036854775808.0 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int64-float-large.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.1--int64-float-large.test.yaml
@@ -10,43 +10,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["POS:9223372036854775808.0", "NEG:-9.223372036854776e+18"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["POS:9223372036854775808.0", "NEG:-9.223372036854776e+18"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.2--string-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.2--string-ops.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["CONCAT:hello world", "REPEAT:ababab", "REPEAT0:0 chars", "IN:true", "NOTIN:true"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["CONCAT:hello world", "REPEAT:ababab", "REPEAT0:0 chars", "IN:true", "NOTIN:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.2--string-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.2--string-ops.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["CONCAT:hello world", "REPEAT:ababab", "REPEAT0:0 chars", "IN:true", "NOTIN:true"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'CONCAT:{{ "hello" + " world" }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.3--list-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.3--list-ops.test.yaml
@@ -6,10 +6,58 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "CONCAT:[1, 2, 3, 4]",
+              "INTFLOAT:[1.0, 2.0, 3.0, 4.0]",
+              "REPEAT:[1, 2, 1, 2]",
+              "REPEAT0:[]",
+              "IN:true",
+              "NOTIN:true",
+              "RANGE_IN:true",
+              "RANGE_NOTIN:true",
+              "RANGE_RANGE:[1, 2, 3, 7, 8, 9]",
+              "EMPTY_CONCAT:[1, 2]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'CONCAT:{{ [1, 2] + [3, 4] }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.3--list-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.3--list-ops.test.yaml
@@ -9,54 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "CONCAT:[1, 2, 3, 4]",
-              "INTFLOAT:[1.0, 2.0, 3.0, 4.0]",
-              "REPEAT:[1, 2, 1, 2]",
-              "REPEAT0:[]",
-              "IN:true",
-              "NOTIN:true",
-              "RANGE_IN:true",
-              "RANGE_NOTIN:true",
-              "RANGE_RANGE:[1, 2, 3, 7, 8, 9]",
-              "EMPTY_CONCAT:[1, 2]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["CONCAT:[1, 2, 3, 4]", "INTFLOAT:[1.0, 2.0, 3.0, 4.0]", "REPEAT:[1, 2, 1, 2]", "REPEAT0:[]", "IN:true", "NOTIN:true", "RANGE_IN:true", "RANGE_NOTIN:true", "RANGE_RANGE:[1, 2, 3, 7, 8, 9]", "EMPTY_CONCAT:[1, 2]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.4--comparisons.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.4--comparisons.test.yaml
@@ -12,65 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "EQ:true",
-              "NE:true",
-              "LT:true",
-              "GT:true",
-              "LE:true",
-              "GE:true",
-              "LE2:true",
-              "GE2:true",
-              "INTFLOAT:true",
-              "BOOLINT:false",
-              "STRINT:false",
-              "CHAIN:true",
-              "STREQ:true",
-              "STRLT:true",
-              "LISTEQ:true",
-              "LISTNE:false",
-              "LISTLT:true",
-              "LISTLEN:true",
-              "BOOL_ORD:true",
-              "PATH_LT:true",
-              "PATH_EQ:true",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["EQ:true", "NE:true", "LT:true", "GT:true", "LE:true", "GE:true", "LE2:true", "GE2:true", "INTFLOAT:true", "BOOLINT:false", "STRINT:false", "CHAIN:true", "STREQ:true", "STRLT:true", "LISTEQ:true", "LISTNE:false", "LISTLT:true", "LISTLEN:true", "BOOL_ORD:true", "PATH_LT:true", "PATH_EQ:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.4--comparisons.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.4--comparisons.test.yaml
@@ -9,10 +9,69 @@ template:
     - 'path_lt = path("/a") < path("/b")'
     - 'path_eq = path("/a") == path("/a")'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "EQ:true",
+              "NE:true",
+              "LT:true",
+              "GT:true",
+              "LE:true",
+              "GE:true",
+              "LE2:true",
+              "GE2:true",
+              "INTFLOAT:true",
+              "BOOLINT:false",
+              "STRINT:false",
+              "CHAIN:true",
+              "STREQ:true",
+              "STRLT:true",
+              "LISTEQ:true",
+              "LISTNE:false",
+              "LISTLT:true",
+              "LISTLEN:true",
+              "BOOL_ORD:true",
+              "PATH_LT:true",
+              "PATH_EQ:true",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'EQ:{{ 5 == 5 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.5--path-host-context.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.5--path-host-context.test.yaml
@@ -10,10 +10,69 @@ template:
     - 'posix_rel = path("sub/file.exr")'
     - 'posix_joined = path("/mnt/output") / "sub" / "file.exr"'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "AS_POSIX:/mnt/renders/scene.exr",
+              "HOST_POSIX_ABS:/mnt/renders/scene.exr",
+              "HOST_REL:sub/file.exr",
+              "HOST_JOIN:/mnt/output/sub/file.exr",
+              "HOST_WIN_ABS:D:/renders/scene.exr",
+              "HOST_PARENT:/mnt/renders",
+              "LET_ABS:/mnt/renders/scene.exr",
+              "LET_REL:sub/file.exr",
+              "LET_JOINED:/mnt/output/sub/file.exr",
+          ]
+          EXPECTED_WINDOWS = [
+              "AS_POSIX:/mnt/renders/scene.exr",
+              "HOST_POSIX_ABS:\\mnt\\renders\\scene.exr",
+              "HOST_REL:sub\\file.exr",
+              "HOST_JOIN:\\mnt\\output\\sub\\file.exr",
+              "HOST_WIN_ABS:D:\\renders\\scene.exr",
+              "HOST_PARENT:\\mnt\\renders",
+              "LET_ABS:\\mnt\\renders\\scene.exr",
+              "LET_REL:sub\\file.exr",
+              "LET_JOINED:\\mnt\\output\\sub\\file.exr",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'HOST_POSIX_ABS:{{ path("/mnt/renders/scene.exr") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.5--path-host-context.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.5--path-host-context.test.yaml
@@ -13,65 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "AS_POSIX:/mnt/renders/scene.exr",
-              "HOST_POSIX_ABS:/mnt/renders/scene.exr",
-              "HOST_REL:sub/file.exr",
-              "HOST_JOIN:/mnt/output/sub/file.exr",
-              "HOST_WIN_ABS:D:/renders/scene.exr",
-              "HOST_PARENT:/mnt/renders",
-              "LET_ABS:/mnt/renders/scene.exr",
-              "LET_REL:sub/file.exr",
-              "LET_JOINED:/mnt/output/sub/file.exr",
-          ]
-          EXPECTED_WINDOWS = [
-              "AS_POSIX:/mnt/renders/scene.exr",
-              "HOST_POSIX_ABS:\\mnt\\renders\\scene.exr",
-              "HOST_REL:sub\\file.exr",
-              "HOST_JOIN:\\mnt\\output\\sub\\file.exr",
-              "HOST_WIN_ABS:D:\\renders\\scene.exr",
-              "HOST_PARENT:\\mnt\\renders",
-              "LET_ABS:\\mnt\\renders\\scene.exr",
-              "LET_REL:sub\\file.exr",
-              "LET_JOINED:\\mnt\\output\\sub\\file.exr",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["AS_POSIX:/mnt/renders/scene.exr", "HOST_POSIX_ABS:/mnt/renders/scene.exr", "HOST_REL:sub/file.exr", "HOST_JOIN:/mnt/output/sub/file.exr", "HOST_WIN_ABS:D:/renders/scene.exr", "HOST_PARENT:/mnt/renders", "LET_ABS:/mnt/renders/scene.exr", "LET_REL:sub/file.exr", "LET_JOINED:/mnt/output/sub/file.exr"], "expected_windows": ["AS_POSIX:/mnt/renders/scene.exr", "HOST_POSIX_ABS:\\mnt\\renders\\scene.exr", "HOST_REL:sub\\file.exr", "HOST_JOIN:\\mnt\\output\\sub\\file.exr", "HOST_WIN_ABS:D:\\renders\\scene.exr", "HOST_PARENT:\\mnt\\renders", "LET_ABS:\\mnt\\renders\\scene.exr", "LET_REL:sub\\file.exr", "LET_JOINED:\\mnt\\output\\sub\\file.exr"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.5--path-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.5--path-ops.test.yaml
@@ -15,10 +15,52 @@ template:
     - 'abs_posix = abs_replace.as_posix()'
     - 'pp_posix = path_path.as_posix()'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "JOIN:/mnt/output/renders/scene.exr",
+              "APPEND:/mnt/output/base.txt",
+              "ABS_REPLACE:/other/path",
+              "PATH_PATH:/mnt/sub/dir",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'JOIN:{{ joined_posix }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.5--path-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.5--path-ops.test.yaml
@@ -18,48 +18,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "JOIN:/mnt/output/renders/scene.exr",
-              "APPEND:/mnt/output/base.txt",
-              "ABS_REPLACE:/other/path",
-              "PATH_PATH:/mnt/sub/dir",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["JOIN:/mnt/output/renders/scene.exr", "APPEND:/mnt/output/base.txt", "ABS_REPLACE:/other/path", "PATH_PATH:/mnt/sub/dir"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.6--and-or-value-returning.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.6--and-or-value-returning.test.yaml
@@ -9,53 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "OR_NULL:fallback",
-              "OR_FALSE:fallback",
-              "OR_STR:hello",
-              "OR_ZERO:0",
-              "OR_EMPTY:[]",
-              "AND_NULL:[]",
-              "AND_TRUE:hello",
-              "AND_STR:world",
-              "BOOL:true",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OR_NULL:fallback", "OR_FALSE:fallback", "OR_STR:hello", "OR_ZERO:0", "OR_EMPTY:[]", "AND_NULL:[]", "AND_TRUE:hello", "AND_STR:world", "BOOL:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.6--and-or-value-returning.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.6--and-or-value-returning.test.yaml
@@ -6,10 +6,57 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "OR_NULL:fallback",
+              "OR_FALSE:fallback",
+              "OR_STR:hello",
+              "OR_ZERO:0",
+              "OR_EMPTY:[]",
+              "AND_NULL:[]",
+              "AND_TRUE:hello",
+              "AND_STR:world",
+              "BOOL:true",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'OR_NULL:{{ null or "fallback" }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.6--logical-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.6--logical-ops.test.yaml
@@ -6,10 +6,55 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "AND:true",
+              "ANDFALSE:false",
+              "OR:true",
+              "ORFALSE:false",
+              "NOT:true",
+              "SHORT:false",
+              "SHORT_OR:true",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'AND:{{ true and true }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.6--logical-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.6--logical-ops.test.yaml
@@ -9,51 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "AND:true",
-              "ANDFALSE:false",
-              "OR:true",
-              "ORFALSE:false",
-              "NOT:true",
-              "SHORT:false",
-              "SHORT_OR:true",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["AND:true", "ANDFALSE:false", "OR:true", "ORFALSE:false", "NOT:true", "SHORT:false", "SHORT_OR:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.7--indexing.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.7--indexing.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["LIST:20", "NEG:30", "STR:h", "STR_NEG:o", "RANGE:7"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'LIST:{{ [10, 20, 30][1] }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.7--indexing.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.7--indexing.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["LIST:20", "NEG:30", "STR:h", "STR_NEG:o", "RANGE:7"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["LIST:20", "NEG:30", "STR:h", "STR_NEG:o", "RANGE:7"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.8--slicing.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.8--slicing.test.yaml
@@ -13,49 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "LSLICE:[20, 30, 40]",
-              "REV:[3, 2, 1]",
-              "SSLICE:ell",
-              "RSLICE:2,3",
-              "RREV:[5, 4, 3, 2, 1]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["LSLICE:[20, 30, 40]", "REV:[3, 2, 1]", "SSLICE:ell", "RSLICE:2,3", "RREV:[5, 4, 3, 2, 1]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.1.8--slicing.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.1.8--slicing.test.yaml
@@ -10,10 +10,53 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "LSLICE:[20, 30, 40]",
+              "REV:[3, 2, 1]",
+              "SSLICE:ell",
+              "RSLICE:2,3",
+              "RREV:[5, 4, 3, 2, 1]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'LSLICE:{{ [10, 20, 30, 40, 50][1:4] }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--bool-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--bool-conversion.test.yaml
@@ -6,10 +6,60 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "INT1:true",
+              "INT0:false",
+              "FLOAT1:true",
+              "FLOAT0:false",
+              "PASS:true",
+              "NULL:false",
+              "TRUE:true",
+              "FALSE:false",
+              "YES:true",
+              "NO:false",
+              "ON:true",
+              "OFF:false",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INT1:{{ bool(1) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--bool-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--bool-conversion.test.yaml
@@ -9,56 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "INT1:true",
-              "INT0:false",
-              "FLOAT1:true",
-              "FLOAT0:false",
-              "PASS:true",
-              "NULL:false",
-              "TRUE:true",
-              "FALSE:false",
-              "YES:true",
-              "NO:false",
-              "ON:true",
-              "OFF:false",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INT1:true", "INT0:false", "FLOAT1:true", "FLOAT0:false", "PASS:true", "NULL:false", "TRUE:true", "FALSE:false", "YES:true", "NO:false", "ON:true", "OFF:false"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--float-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--float-conversion.test.yaml
@@ -6,10 +6,56 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "INT:3.0",
+              "STR:2.5",
+              "STR_INT:42.0",
+              "SCI:1500.0",
+              "SCI_NEG:0.25",
+              "LEADING:2.5",
+              "TRAILING:2.5",
+              "BOTH:2.5",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INT:{{ float(3) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--float-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--float-conversion.test.yaml
@@ -9,52 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "INT:3.0",
-              "STR:2.5",
-              "STR_INT:42.0",
-              "SCI:1500.0",
-              "SCI_NEG:0.25",
-              "LEADING:2.5",
-              "TRAILING:2.5",
-              "BOTH:2.5",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INT:3.0", "STR:2.5", "STR_INT:42.0", "SCI:1500.0", "SCI_NEG:0.25", "LEADING:2.5", "TRAILING:2.5", "BOTH:2.5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--int-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--int-conversion.test.yaml
@@ -9,52 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "FLOAT:3",
-              "STR:42",
-              "SCI:100",
-              "NEG:-5",
-              "STR_NEG:-7",
-              "LEADING:42",
-              "TRAILING:42",
-              "BOTH:42",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["FLOAT:3", "STR:42", "SCI:100", "NEG:-5", "STR_NEG:-7", "LEADING:42", "TRAILING:42", "BOTH:42"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--int-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--int-conversion.test.yaml
@@ -6,10 +6,56 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "FLOAT:3",
+              "STR:42",
+              "SCI:100",
+              "NEG:-5",
+              "STR_NEG:-7",
+              "LEADING:42",
+              "TRAILING:42",
+              "BOTH:42",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'FLOAT:{{ int(3.0) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--len.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--len.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["LIST:3", "STR:5", "RANGE:5", "PATH:8"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'LIST:{{ len([10, 20, 30]) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--len.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--len.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["LIST:3", "STR:5", "RANGE:5", "PATH:8"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["LIST:3", "STR:5", "RANGE:5", "PATH:8"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--list-from-range-expr.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--list-from-range-expr.test.yaml
@@ -9,50 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "SIMPLE:[1, 2, 3]",
-              "STEP:[1, 3, 5, 7, 9]",
-              "DESC:[1, 2, 3, 4, 5]",
-              "VALUES:[2, 6, 9]",
-              "MIXED:[1, 2, 3, 10, 20, 21, 22]",
-              "FROM_LIST:[1, 2, 3]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SIMPLE:[1, 2, 3]", "STEP:[1, 3, 5, 7, 9]", "DESC:[1, 2, 3, 4, 5]", "VALUES:[2, 6, 9]", "MIXED:[1, 2, 3, 10, 20, 21, 22]", "FROM_LIST:[1, 2, 3]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--list-from-range-expr.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--list-from-range-expr.test.yaml
@@ -6,10 +6,54 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "SIMPLE:[1, 2, 3]",
+              "STEP:[1, 3, 5, 7, 9]",
+              "DESC:[1, 2, 3, 4, 5]",
+              "VALUES:[2, 6, 9]",
+              "MIXED:[1, 2, 3, 10, 20, 21, 22]",
+              "FROM_LIST:[1, 2, 3]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SIMPLE:{{ list(range_expr("1-3")) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--range-expr-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--range-expr-conversion.test.yaml
@@ -9,51 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "STR:1-3",
-              "LIST:1-3",
-              "STEP:1-9:2",
-              "DESC:1-5",
-              "VALUES:2,6,9",
-              "MIXED:1-3,10,20-22",
-              "COMPLEX:-2,-1,3-5,7-9,12,100",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["STR:1-3", "LIST:1-3", "STEP:1-9:2", "DESC:1-5", "VALUES:2,6,9", "MIXED:1-3,10,20-22", "COMPLEX:-2,-1,3-5,7-9,12,100"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--range-expr-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--range-expr-conversion.test.yaml
@@ -6,10 +6,55 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "STR:1-3",
+              "LIST:1-3",
+              "STEP:1-9:2",
+              "DESC:1-5",
+              "VALUES:2,6,9",
+              "MIXED:1-3,10,20-22",
+              "COMPLEX:-2,-1,3-5,7-9,12,100",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'STR:{{ range_expr("1-3") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--string-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--string-conversion.test.yaml
@@ -12,53 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "INT:42",
-              "FLOAT:3.14",
-              "BOOL_T:true",
-              "BOOL_F:false",
-              "STR:hello",
-              "NULL:null",
-              "PATH:/mnt/out",
-              "RANGE:1-5",
-              "LIST:[1, 2, 3]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INT:42", "FLOAT:3.14", "BOOL_T:true", "BOOL_F:false", "STR:hello", "NULL:null", "PATH:/mnt/out", "RANGE:1-5", "LIST:[1, 2, 3]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--string-conversion.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--string-conversion.test.yaml
@@ -9,10 +9,57 @@ template:
     let:
     - 'from_path = string(path("/mnt/out"))'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "INT:42",
+              "FLOAT:3.14",
+              "BOOL_T:true",
+              "BOOL_F:false",
+              "STR:hello",
+              "NULL:null",
+              "PATH:/mnt/out",
+              "RANGE:1-5",
+              "LIST:[1, 2, 3]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INT:{{ string(42) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--abs.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--abs.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["INT:5", "FLOAT:3.14", "POS:5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INT:{{ abs(-5) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--abs.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--abs.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["INT:5", "FLOAT:3.14", "POS:5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INT:5", "FLOAT:3.14", "POS:5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--floor-ceil.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--floor-ceil.test.yaml
@@ -9,52 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "FLOOR:3",
-              "CEIL:4",
-              "FLOOR_NEG:-4",
-              "CEIL_NEG:-3",
-              "FLOOR_INT:5",
-              "CEIL_INT:5",
-              "FLOOR_EXACT:4",
-              "CEIL_EXACT:4",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["FLOOR:3", "CEIL:4", "FLOOR_NEG:-4", "CEIL_NEG:-3", "FLOOR_INT:5", "CEIL_INT:5", "FLOOR_EXACT:4", "CEIL_EXACT:4"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--floor-ceil.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--floor-ceil.test.yaml
@@ -6,10 +6,56 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "FLOOR:3",
+              "CEIL:4",
+              "FLOOR_NEG:-4",
+              "CEIL_NEG:-3",
+              "FLOOR_INT:5",
+              "CEIL_INT:5",
+              "FLOOR_EXACT:4",
+              "CEIL_EXACT:4",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'FLOOR:{{ floor(3.7) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--max.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--max.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["TWO:3", "THREE:3", "LIST:8", "RANGE:7", "FLOAT:2.5", "MIXED:2.5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["TWO:3", "THREE:3", "LIST:8", "RANGE:7", "FLOAT:2.5", "MIXED:2.5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--max.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--max.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["TWO:3", "THREE:3", "LIST:8", "RANGE:7", "FLOAT:2.5", "MIXED:2.5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'TWO:{{ max(3, 1) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--min.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--min.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["TWO:1", "THREE:1", "LIST:2", "RANGE:3", "MIXED:1.0"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["TWO:1", "THREE:1", "LIST:2", "RANGE:3", "MIXED:1.0"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--min.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--min.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["TWO:1", "THREE:1", "LIST:2", "RANGE:3", "MIXED:1.0"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'TWO:{{ min(3, 1) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--round-bankers.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--round-bankers.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["R0:0", "R1:2", "R2:2"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["R0:0", "R1:2", "R2:2"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--round-bankers.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--round-bankers.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["R0:0", "R1:2", "R2:2"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'R0:{{ round(0.5) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--round.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--round.test.yaml
@@ -6,10 +6,58 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "HALF_EVEN:2",
+              "HALF_EVEN2:4",
+              "NEG_HALF_EVEN:-2",
+              "NEG_HALF_EVEN2:-4",
+              "DIGITS:3.14",
+              "TRAILING:3.50",
+              "TENS:1230",
+              "HUNDREDS:1200",
+              "ZERO_NDIGITS:4",
+              "INT_NDIGITS:5",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'HALF_EVEN:{{ round(2.5) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--round.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--round.test.yaml
@@ -9,54 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "HALF_EVEN:2",
-              "HALF_EVEN2:4",
-              "NEG_HALF_EVEN:-2",
-              "NEG_HALF_EVEN2:-4",
-              "DIGITS:3.14",
-              "TRAILING:3.50",
-              "TENS:1230",
-              "HUNDREDS:1200",
-              "ZERO_NDIGITS:4",
-              "INT_NDIGITS:5",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["HALF_EVEN:2", "HALF_EVEN2:4", "NEG_HALF_EVEN:-2", "NEG_HALF_EVEN2:-4", "DIGITS:3.14", "TRAILING:3.50", "TENS:1230", "HUNDREDS:1200", "ZERO_NDIGITS:4", "INT_NDIGITS:5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--sum.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--sum.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["INT_LIST:6", "EMPTY:0", "RANGE:15", "FLOAT_LIST:7.0", "SINGLE:42", "NEGATIVE:0"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INT_LIST:{{ sum([1, 2, 3]) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--sum.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.2--sum.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["INT_LIST:6", "EMPTY:0", "RANGE:15", "FLOAT_LIST:7.0", "SINGLE:42", "NEGATIVE:0"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INT_LIST:6", "EMPTY:0", "RANGE:15", "FLOAT_LIST:7.0", "SINGLE:42", "NEGATIVE:0"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--any-all.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--any-all.test.yaml
@@ -6,10 +6,54 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "ANY_T:true",
+              "ANY_F:false",
+              "ANY_EMPTY:false",
+              "ALL_T:true",
+              "ALL_F:false",
+              "ALL_EMPTY:true",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'ANY_T:{{ any([false, true]) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--any-all.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--any-all.test.yaml
@@ -9,50 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "ANY_T:true",
-              "ANY_F:false",
-              "ANY_EMPTY:false",
-              "ALL_T:true",
-              "ALL_F:false",
-              "ALL_EMPTY:true",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ANY_T:true", "ANY_F:false", "ANY_EMPTY:false", "ALL_T:true", "ALL_F:false", "ALL_EMPTY:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--flatten.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--flatten.test.yaml
@@ -12,63 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "INT:[1, 2, 3]",
-              "STR:[\"a\", \"b\", \"c\"]",
-              "SINGLES:[1, 2, 3]",
-              "MIXED_LEN:[1, 2, 3]",
-              "EMPTY:[]",
-              "FLAT_INT:[1, 2, 3]",
-              "FLAT_STR:[\"a\", \"b\"]",
-              "PATH:[\"/a\", \"/b\", \"/c\"]",
-          ]
-          EXPECTED_WINDOWS = [
-              "INT:[1, 2, 3]",
-              "STR:[\"a\", \"b\", \"c\"]",
-              "SINGLES:[1, 2, 3]",
-              "MIXED_LEN:[1, 2, 3]",
-              "EMPTY:[]",
-              "FLAT_INT:[1, 2, 3]",
-              "FLAT_STR:[\"a\", \"b\"]",
-              "PATH:[\"\\a\", \"\\b\", \"\\c\"]",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["INT:[1, 2, 3]", "STR:[\"a\", \"b\", \"c\"]", "SINGLES:[1, 2, 3]", "MIXED_LEN:[1, 2, 3]", "EMPTY:[]", "FLAT_INT:[1, 2, 3]", "FLAT_STR:[\"a\", \"b\"]", "PATH:[\"/a\", \"/b\", \"/c\"]"], "expected_windows": ["INT:[1, 2, 3]", "STR:[\"a\", \"b\", \"c\"]", "SINGLES:[1, 2, 3]", "MIXED_LEN:[1, 2, 3]", "EMPTY:[]", "FLAT_INT:[1, 2, 3]", "FLAT_STR:[\"a\", \"b\"]", "PATH:[\"\\a\", \"\\b\", \"\\c\"]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--flatten.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--flatten.test.yaml
@@ -9,10 +9,67 @@ template:
     let:
     - 'paths = flatten([[path("/a"), path("/b")], [path("/c")]])'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "INT:[1, 2, 3]",
+              "STR:[\"a\", \"b\", \"c\"]",
+              "SINGLES:[1, 2, 3]",
+              "MIXED_LEN:[1, 2, 3]",
+              "EMPTY:[]",
+              "FLAT_INT:[1, 2, 3]",
+              "FLAT_STR:[\"a\", \"b\"]",
+              "PATH:[\"/a\", \"/b\", \"/c\"]",
+          ]
+          EXPECTED_WINDOWS = [
+              "INT:[1, 2, 3]",
+              "STR:[\"a\", \"b\", \"c\"]",
+              "SINGLES:[1, 2, 3]",
+              "MIXED_LEN:[1, 2, 3]",
+              "EMPTY:[]",
+              "FLAT_INT:[1, 2, 3]",
+              "FLAT_STR:[\"a\", \"b\"]",
+              "PATH:[\"\\a\", \"\\b\", \"\\c\"]",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INT:{{ flatten([[1, 2], [3]]) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--range.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--range.test.yaml
@@ -9,50 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "STOP:[0, 1, 2, 3, 4]",
-              "START_STOP:[1, 2, 3, 4]",
-              "STEP:[0, 2, 4, 6, 8]",
-              "NEG:[5, 4, 3, 2, 1]",
-              "EMPTY:[]",
-              "EMPTY2:[]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["STOP:[0, 1, 2, 3, 4]", "START_STOP:[1, 2, 3, 4]", "STEP:[0, 2, 4, 6, 8]", "NEG:[5, 4, 3, 2, 1]", "EMPTY:[]", "EMPTY2:[]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--range.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--range.test.yaml
@@ -6,10 +6,54 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "STOP:[0, 1, 2, 3, 4]",
+              "START_STOP:[1, 2, 3, 4]",
+              "STEP:[0, 2, 4, 6, 8]",
+              "NEG:[5, 4, 3, 2, 1]",
+              "EMPTY:[]",
+              "EMPTY2:[]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'STOP:{{ range(5) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--reversed.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--reversed.test.yaml
@@ -9,49 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "INT:[2, 1, 3]",
-              "STR:[\"b\", \"a\", \"c\"]",
-              "SINGLE:[42]",
-              "NESTED:[[1, 3, 5], [], [1]]",
-              "EMPTY:[]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INT:[2, 1, 3]", "STR:[\"b\", \"a\", \"c\"]", "SINGLE:[42]", "NESTED:[[1, 3, 5], [], [1]]", "EMPTY:[]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--reversed.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--reversed.test.yaml
@@ -6,10 +6,53 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "INT:[2, 1, 3]",
+              "STR:[\"b\", \"a\", \"c\"]",
+              "SINGLE:[42]",
+              "NESTED:[[1, 3, 5], [], [1]]",
+              "EMPTY:[]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INT:{{ reversed([3, 1, 2]) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--sorted.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--sorted.test.yaml
@@ -6,10 +6,54 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "INT:[1, 2, 3]",
+              "STR:[\"a\", \"b\", \"c\"]",
+              "ALREADY:[1, 2, 3]",
+              "EMPTY:[]",
+              "FLOAT:[1.0, 2.5, 3.5]",
+              "NESTED:[[], [1], [1, 2], [1, 3]]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'INT:{{ sorted([3, 1, 2]) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--sorted.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--sorted.test.yaml
@@ -9,50 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "INT:[1, 2, 3]",
-              "STR:[\"a\", \"b\", \"c\"]",
-              "ALREADY:[1, 2, 3]",
-              "EMPTY:[]",
-              "FLOAT:[1.0, 2.5, 3.5]",
-              "NESTED:[[], [1], [1, 2], [1, 3]]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INT:[1, 2, 3]", "STR:[\"a\", \"b\", \"c\"]", "ALREADY:[1, 2, 3]", "EMPTY:[]", "FLOAT:[1.0, 2.5, 3.5]", "NESTED:[[], [1], [1, 2], [1, 3]]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--unique.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--unique.test.yaml
@@ -6,10 +6,81 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "BOOL:[[True, False]]",
+              "INT:[[3, 1, 2]]",
+              "FLOAT:[[1.5, 2.5, 3.5]]",
+              "STR:[a,b,c]",
+              "RANGE_EXPR:[2]",
+              "LIST_INT:[[[1, 2], [3, 4]]]",
+              "LIST_STR:[[['a'], ['b']]]",
+              "LIST_FLOAT:[[[1.0], [2.0]]]",
+              "LIST_BOOL:[[[True], [False]]]",
+              "EMPTY:[[]]",
+              "ALL_SAME:[[7]]",
+              "METHOD:[[1, 2, 3]]",
+              "CHAINED:[[1, 2, 3]]",
+              "PATH:[['/a', '/b']]",
+              "LIST_PATH:[[['/a'], ['/b']]]",
+          ]
+          EXPECTED_WINDOWS = [
+              "BOOL:[[True, False]]",
+              "INT:[[3, 1, 2]]",
+              "FLOAT:[[1.5, 2.5, 3.5]]",
+              "STR:[a,b,c]",
+              "RANGE_EXPR:[2]",
+              "LIST_INT:[[[1, 2], [3, 4]]]",
+              "LIST_STR:[[['a'], ['b']]]",
+              "LIST_FLOAT:[[[1.0], [2.0]]]",
+              "LIST_BOOL:[[[True], [False]]]",
+              "EMPTY:[[]]",
+              "ALL_SAME:[[7]]",
+              "METHOD:[[1, 2, 3]]",
+              "CHAINED:[[1, 2, 3]]",
+              "PATH:[['\\\\a', '\\\\b']]",
+              "LIST_PATH:[[['\\\\a'], ['\\\\b']]]",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'BOOL:[{{ repr_py(unique([True, False, True, False])) }}]')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--unique.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--unique.test.yaml
@@ -9,77 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "BOOL:[[True, False]]",
-              "INT:[[3, 1, 2]]",
-              "FLOAT:[[1.5, 2.5, 3.5]]",
-              "STR:[a,b,c]",
-              "RANGE_EXPR:[2]",
-              "LIST_INT:[[[1, 2], [3, 4]]]",
-              "LIST_STR:[[['a'], ['b']]]",
-              "LIST_FLOAT:[[[1.0], [2.0]]]",
-              "LIST_BOOL:[[[True], [False]]]",
-              "EMPTY:[[]]",
-              "ALL_SAME:[[7]]",
-              "METHOD:[[1, 2, 3]]",
-              "CHAINED:[[1, 2, 3]]",
-              "PATH:[['/a', '/b']]",
-              "LIST_PATH:[[['/a'], ['/b']]]",
-          ]
-          EXPECTED_WINDOWS = [
-              "BOOL:[[True, False]]",
-              "INT:[[3, 1, 2]]",
-              "FLOAT:[[1.5, 2.5, 3.5]]",
-              "STR:[a,b,c]",
-              "RANGE_EXPR:[2]",
-              "LIST_INT:[[[1, 2], [3, 4]]]",
-              "LIST_STR:[[['a'], ['b']]]",
-              "LIST_FLOAT:[[[1.0], [2.0]]]",
-              "LIST_BOOL:[[[True], [False]]]",
-              "EMPTY:[[]]",
-              "ALL_SAME:[[7]]",
-              "METHOD:[[1, 2, 3]]",
-              "CHAINED:[[1, 2, 3]]",
-              "PATH:[['\\\\a', '\\\\b']]",
-              "LIST_PATH:[[['\\\\a'], ['\\\\b']]]",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["BOOL:[[True, False]]", "INT:[[3, 1, 2]]", "FLOAT:[[1.5, 2.5, 3.5]]", "STR:[a,b,c]", "RANGE_EXPR:[2]", "LIST_INT:[[[1, 2], [3, 4]]]", "LIST_STR:[[['a'], ['b']]]", "LIST_FLOAT:[[[1.0], [2.0]]]", "LIST_BOOL:[[[True], [False]]]", "EMPTY:[[]]", "ALL_SAME:[[7]]", "METHOD:[[1, 2, 3]]", "CHAINED:[[1, 2, 3]]", "PATH:[['/a', '/b']]", "LIST_PATH:[[['/a'], ['/b']]]"], "expected_windows": ["BOOL:[[True, False]]", "INT:[[3, 1, 2]]", "FLOAT:[[1.5, 2.5, 3.5]]", "STR:[a,b,c]", "RANGE_EXPR:[2]", "LIST_INT:[[[1, 2], [3, 4]]]", "LIST_STR:[[['a'], ['b']]]", "LIST_FLOAT:[[[1.0], [2.0]]]", "LIST_BOOL:[[[True], [False]]]", "EMPTY:[[]]", "ALL_SAME:[[7]]", "METHOD:[[1, 2, 3]]", "CHAINED:[[1, 2, 3]]", "PATH:[['\\\\a', '\\\\b']]", "LIST_PATH:[[['\\\\a'], ['\\\\b']]]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--case-transforms.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--case-transforms.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["UPPER:HELLO", "LOWER:hello", "CAP:Hello world", "TITLE:Hello World"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'UPPER:{{ upper("hello") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--case-transforms.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--case-transforms.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["UPPER:HELLO", "LOWER:hello", "CAP:Hello world", "TITLE:Hello World"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["UPPER:HELLO", "LOWER:hello", "CAP:Hello world", "TITLE:Hello World"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--find-index.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--find-index.test.yaml
@@ -9,50 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "FIND:[1]",
-              "FIND_MISS:[-1]",
-              "RFIND:[4]",
-              "RFIND_MISS:[-1]",
-              "INDEX:[1]",
-              "RINDEX:[4]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["FIND:[1]", "FIND_MISS:[-1]", "RFIND:[4]", "RFIND_MISS:[-1]", "INDEX:[1]", "RINDEX:[4]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--find-index.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--find-index.test.yaml
@@ -6,10 +6,54 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "FIND:[1]",
+              "FIND_MISS:[-1]",
+              "RFIND:[4]",
+              "RFIND_MISS:[-1]",
+              "INDEX:[1]",
+              "RINDEX:[4]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'FIND:[{{ find("hello", "ell") }}]')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--find.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--find.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["FOUND:6", "NOT_FOUND:-1", "START:0"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["FOUND:6", "NOT_FOUND:-1", "START:0"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--find.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--find.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["FOUND:6", "NOT_FOUND:-1", "START:0"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'FOUND:{{ find("hello world", "world") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--padding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--padding.test.yaml
@@ -9,58 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "ZFILL:00042",
-              "ZFILL_INT:0007",
-              "ZFILL_METHOD:00042",
-              "ZFILL_INT_METHOD:0007",
-              "ZFILL_NEG_INT:-01",
-              "ZFILL_NEG_STR:-010",
-              "ZFILL_PLUS:+005",
-              "ZFILL_FLOAT:00003.14",
-              "ZFILL_FLOAT_NEG:-00002.5",
-              "ZFILL_FLOAT_METHOD:00003.14",
-              "ZFILL_FLOAT_ROUND:0000.30",
-              "LJUST:[hi    ]",
-              "RJUST:[    hi]",
-              "CENTER:[  hi  ]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ZFILL:00042", "ZFILL_INT:0007", "ZFILL_METHOD:00042", "ZFILL_INT_METHOD:0007", "ZFILL_NEG_INT:-01", "ZFILL_NEG_STR:-010", "ZFILL_PLUS:+005", "ZFILL_FLOAT:00003.14", "ZFILL_FLOAT_NEG:-00002.5", "ZFILL_FLOAT_METHOD:00003.14", "ZFILL_FLOAT_ROUND:0000.30", "LJUST:[hi    ]", "RJUST:[    hi]", "CENTER:[  hi  ]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--padding.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--padding.test.yaml
@@ -6,10 +6,62 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "ZFILL:00042",
+              "ZFILL_INT:0007",
+              "ZFILL_METHOD:00042",
+              "ZFILL_INT_METHOD:0007",
+              "ZFILL_NEG_INT:-01",
+              "ZFILL_NEG_STR:-010",
+              "ZFILL_PLUS:+005",
+              "ZFILL_FLOAT:00003.14",
+              "ZFILL_FLOAT_NEG:-00002.5",
+              "ZFILL_FLOAT_METHOD:00003.14",
+              "ZFILL_FLOAT_ROUND:0000.30",
+              "LJUST:[hi    ]",
+              "RJUST:[    hi]",
+              "CENTER:[  hi  ]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'ZFILL:{{ zfill("42", 5) }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--removeprefix-removesuffix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--removeprefix-removesuffix.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RP_MATCH:Hook", "RP_NONE:TestHook", "RS_MATCH:render", "RS_NONE:render.exr"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RP_MATCH:Hook", "RP_NONE:TestHook", "RS_MATCH:render", "RS_NONE:render.exr"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--removeprefix-removesuffix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--removeprefix-removesuffix.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RP_MATCH:Hook", "RP_NONE:TestHook", "RS_MATCH:render", "RS_NONE:render.exr"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'RP_MATCH:{{ removeprefix("TestHook", "Test") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--replace.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--replace.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MATCH:herro", "NONE:hello"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'MATCH:{{ replace("hello", "l", "r") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--replace.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--replace.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MATCH:herro", "NONE:hello"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MATCH:herro", "NONE:hello"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--rsplit.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--rsplit.test.yaml
@@ -6,10 +6,54 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "SPLIT:a;b;c",
+              "SPLIT_MAX:a;b;c,d",
+              "RSPLIT:a;b;c",
+              "RSPLIT_MAX:a,b;c;d",
+              "METHOD:a;b/c/d",
+              "RMETHOD:a/b/c;d",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SPLIT:{{ split("a,b,c", ",").join(";") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--rsplit.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--rsplit.test.yaml
@@ -9,50 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "SPLIT:a;b;c",
-              "SPLIT_MAX:a;b;c,d",
-              "RSPLIT:a;b;c",
-              "RSPLIT_MAX:a,b;c;d",
-              "METHOD:a;b/c/d",
-              "RMETHOD:a/b/c;d",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SPLIT:a;b;c", "SPLIT_MAX:a;b;c,d", "RSPLIT:a;b;c", "RSPLIT_MAX:a,b;c;d", "METHOD:a;b/c/d", "RMETHOD:a/b/c;d"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--search-test.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--search-test.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["SW_T:true", "SW_F:false", "EW_T:true", "EW_F:false", "COUNT:2", "COUNT_ZERO:0"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SW_T:{{ startswith("hello", "hel") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--search-test.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--search-test.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["SW_T:true", "SW_F:false", "EW_T:true", "EW_F:false", "COUNT:2", "COUNT_ZERO:0"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SW_T:true", "SW_F:false", "EW_T:true", "EW_F:false", "COUNT:2", "COUNT_ZERO:0"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-empty-string.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-empty-string.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["SPLIT:[\"\"]", "LEN:1"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SPLIT:[\"\"]", "LEN:1"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-empty-string.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-empty-string.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["SPLIT:[\"\"]", "LEN:1"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SPLIT:{{ "".split(",") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-join.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-join.test.yaml
@@ -10,10 +10,52 @@ template:
     - 'paths = [path("/a"), path("/b"), path("/c")]'
     - 'path_join = join(paths, ":")'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "SPLIT:[\"a\", \"b\", \"c\"]",
+              "JOIN:a-b-c",
+              "PATH_JOIN:/a:/b:/c",
+              "EMPTY_JOIN:0 chars",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SPLIT:{{ split("a,b,c", ",") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-join.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-join.test.yaml
@@ -13,48 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "SPLIT:[\"a\", \"b\", \"c\"]",
-              "JOIN:a-b-c",
-              "PATH_JOIN:/a:/b:/c",
-              "EMPTY_JOIN:0 chars",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SPLIT:[\"a\", \"b\", \"c\"]", "JOIN:a-b-c", "PATH_JOIN:/a:/b:/c", "EMPTY_JOIN:0 chars"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-whitespace.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-whitespace.test.yaml
@@ -9,51 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "SPLIT:[hello,world]",
-              "SPLIT_TABS:[a,b,c]",
-              "SPLIT_NEWLINES:[a,b,c]",
-              "SPLIT_MIXED:[a,b,c]",
-              "SPLIT_EMPTY:[0]",
-              "RSPLIT:[hello,world]",
-              "RSPLIT_MIXED:[a,b,c]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SPLIT:[hello,world]", "SPLIT_TABS:[a,b,c]", "SPLIT_NEWLINES:[a,b,c]", "SPLIT_MIXED:[a,b,c]", "SPLIT_EMPTY:[0]", "RSPLIT:[hello,world]", "RSPLIT_MIXED:[a,b,c]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-whitespace.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--split-whitespace.test.yaml
@@ -6,10 +6,55 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "SPLIT:[hello,world]",
+              "SPLIT_TABS:[a,b,c]",
+              "SPLIT_NEWLINES:[a,b,c]",
+              "SPLIT_MIXED:[a,b,c]",
+              "SPLIT_EMPTY:[0]",
+              "RSPLIT:[hello,world]",
+              "RSPLIT_MIXED:[a,b,c]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SPLIT:[{{ split("  hello   world  ").join(",") }}]')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--string-classification.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--string-classification.test.yaml
@@ -6,10 +6,63 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "ISDIGIT_T:[true]",
+              "ISDIGIT_F:[false]",
+              "ISDIGIT_E:[false]",
+              "ISALPHA_T:[true]",
+              "ISALPHA_F:[false]",
+              "ISALNUM_T:[true]",
+              "ISALNUM_F:[false]",
+              "ISSPACE_T:[true]",
+              "ISSPACE_F:[false]",
+              "ISUPPER_T:[true]",
+              "ISUPPER_F:[false]",
+              "ISLOWER_T:[true]",
+              "ISLOWER_F:[false]",
+              "ISASCII_T:[true]",
+              "ISASCII_E:[true]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'ISDIGIT_T:[{{ "123".isdigit() }}]')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--string-classification.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--string-classification.test.yaml
@@ -9,59 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "ISDIGIT_T:[true]",
-              "ISDIGIT_F:[false]",
-              "ISDIGIT_E:[false]",
-              "ISALPHA_T:[true]",
-              "ISALPHA_F:[false]",
-              "ISALNUM_T:[true]",
-              "ISALNUM_F:[false]",
-              "ISSPACE_T:[true]",
-              "ISSPACE_F:[false]",
-              "ISUPPER_T:[true]",
-              "ISUPPER_F:[false]",
-              "ISLOWER_T:[true]",
-              "ISLOWER_F:[false]",
-              "ISASCII_T:[true]",
-              "ISASCII_E:[true]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ISDIGIT_T:[true]", "ISDIGIT_F:[false]", "ISDIGIT_E:[false]", "ISALPHA_T:[true]", "ISALPHA_F:[false]", "ISALNUM_T:[true]", "ISALNUM_F:[false]", "ISSPACE_T:[true]", "ISSPACE_F:[false]", "ISUPPER_T:[true]", "ISUPPER_F:[false]", "ISLOWER_T:[true]", "ISLOWER_F:[false]", "ISASCII_T:[true]", "ISASCII_E:[true]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--strip-chars.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--strip-chars.test.yaml
@@ -9,49 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "STRIP:[hello]",
-              "LSTRIP:[helloxx]",
-              "RSTRIP:[xxhello]",
-              "STRIP_MULTI:[HELLO]",
-              "METHOD:[hi]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["STRIP:[hello]", "LSTRIP:[helloxx]", "RSTRIP:[xxhello]", "STRIP_MULTI:[HELLO]", "METHOD:[hi]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--strip-chars.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--strip-chars.test.yaml
@@ -6,10 +6,53 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "STRIP:[hello]",
+              "LSTRIP:[helloxx]",
+              "RSTRIP:[xxhello]",
+              "STRIP_MULTI:[HELLO]",
+              "METHOD:[hi]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'STRIP:[{{ strip("xxhelloxx", "x") }}]')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--strip.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--strip.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["STRIP:[hi]", "LSTRIP:[hi  ]", "RSTRIP:[  hi]"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["STRIP:[hi]", "LSTRIP:[hi  ]", "RSTRIP:[  hi]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--strip.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.4--strip.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["STRIP:[hi]", "LSTRIP:[hi  ]", "RSTRIP:[  hi]"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'STRIP:[{{ strip("  hi  ") }}]')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-escape.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-escape.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["DOT:file\\.exr", "BRACKETS:file\\[1\\]\\.txt"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'DOT:{{ re_escape("file.exr") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-escape.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-escape.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["DOT:file\\.exr", "BRACKETS:file\\[1\\]\\.txt"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["DOT:file\\.exr", "BRACKETS:file\\[1\\]\\.txt"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-findall.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-findall.test.yaml
@@ -9,48 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "PLAIN:[\"1\", \"2\", \"3\"]",
-              "ONE_GROUP:[\"010\", \"020\"]",
-              "MULTI_GROUP:[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"6\"]]",
-              "NO_MATCH:[]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["PLAIN:[\"1\", \"2\", \"3\"]", "ONE_GROUP:[\"010\", \"020\"]", "MULTI_GROUP:[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"6\"]]", "NO_MATCH:[]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-findall.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-findall.test.yaml
@@ -6,10 +6,52 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "PLAIN:[\"1\", \"2\", \"3\"]",
+              "ONE_GROUP:[\"010\", \"020\"]",
+              "MULTI_GROUP:[[\"1\", \"2\", \"3\"], [\"4\", \"5\", \"6\"]]",
+              "NO_MATCH:[]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'PLAIN:{{ re_findall("a1b2c3", r"\d+") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-match.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-match.test.yaml
@@ -9,48 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "ONE_GROUP:[\"v042\", \"042\"]",
-              "NO_GROUPS:[\"hello\"]",
-              "MULTI:[\"shot010_v003\", \"010\", \"003\"]",
-              "NONE:true",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ONE_GROUP:[\"v042\", \"042\"]", "NO_GROUPS:[\"hello\"]", "MULTI:[\"shot010_v003\", \"010\", \"003\"]", "NONE:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-match.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-match.test.yaml
@@ -6,10 +6,52 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "ONE_GROUP:[\"v042\", \"042\"]",
+              "NO_GROUPS:[\"hello\"]",
+              "MULTI:[\"shot010_v003\", \"010\", \"003\"]",
+              "NONE:true",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'ONE_GROUP:{{ re_match("v042_final", r"v(\d+)") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-portable-syntax.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-portable-syntax.test.yaml
@@ -6,10 +6,55 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "DOLLAR:true",
+              "CARET:true",
+              "WORD_BOUND:[\"cat\"]",
+              "NON_CAPTURE:[\"ab\", \"b\"]",
+              "ALTERNATION:[\"cat\", \"bat\", \"hat\"]",
+              "QUANTIFIER:aab",
+              "NON_GREEDY:<a>",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'DOLLAR:{{ re_search("hello", r"llo$") != null }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-portable-syntax.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-portable-syntax.test.yaml
@@ -9,51 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "DOLLAR:true",
-              "CARET:true",
-              "WORD_BOUND:[\"cat\"]",
-              "NON_CAPTURE:[\"ab\", \"b\"]",
-              "ALTERNATION:[\"cat\", \"bat\", \"hat\"]",
-              "QUANTIFIER:aab",
-              "NON_GREEDY:<a>",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["DOLLAR:true", "CARET:true", "WORD_BOUND:[\"cat\"]", "NON_CAPTURE:[\"ab\", \"b\"]", "ALTERNATION:[\"cat\", \"bat\", \"hat\"]", "QUANTIFIER:aab", "NON_GREEDY:<a>"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-search.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-search.test.yaml
@@ -6,10 +6,54 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "FULL:_v042",
+              "GROUP:042",
+              "NO_GROUPS:123",
+              "MULTI:[\"shot010_v003\", \"010\", \"003\"]",
+              "NONE:true",
+              "ANCHOR:true",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'FULL:{{ re_search("asset_v042_final.abc", r"_v(\d+)")[0] }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-search.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-search.test.yaml
@@ -9,50 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "FULL:_v042",
-              "GROUP:042",
-              "NO_GROUPS:123",
-              "MULTI:[\"shot010_v003\", \"010\", \"003\"]",
-              "NONE:true",
-              "ANCHOR:true",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["FULL:_v042", "GROUP:042", "NO_GROUPS:123", "MULTI:[\"shot010_v003\", \"010\", \"003\"]", "NONE:true", "ANCHOR:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-split.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-split.test.yaml
@@ -6,10 +6,56 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "DELIM:[one|two|three]",
+              "DIGITS:[abc|def|ghi|]",
+              "WHITESPACE:[hello|world|foo|bar]",
+              "MULTI_CHAR:[foo|bar|baz]",
+              "MAXSPLIT:[a|b|c3d4e]",
+              "NO_MATCH:[hello]",
+              "METHOD:[2024|01|15]",
+              "KV_PAIRS:[key1|val1|key2|val2|key3|val3]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'DELIM:[{{ re_split("one,two;three", r"[,;]").join("|") }}]')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-split.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-split.test.yaml
@@ -9,52 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "DELIM:[one|two|three]",
-              "DIGITS:[abc|def|ghi|]",
-              "WHITESPACE:[hello|world|foo|bar]",
-              "MULTI_CHAR:[foo|bar|baz]",
-              "MAXSPLIT:[a|b|c3d4e]",
-              "NO_MATCH:[hello]",
-              "METHOD:[2024|01|15]",
-              "KV_PAIRS:[key1|val1|key2|val2|key3|val3]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["DELIM:[one|two|three]", "DIGITS:[abc|def|ghi|]", "WHITESPACE:[hello|world|foo|bar]", "MULTI_CHAR:[foo|bar|baz]", "MAXSPLIT:[a|b|c3d4e]", "NO_MATCH:[hello]", "METHOD:[2024|01|15]", "KV_PAIRS:[key1|val1|key2|val2|key3|val3]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-sub.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-sub.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["SINGLE:frame_002", "MULTI:aXbXcX", "NO_MATCH:hello"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SINGLE:frame_002", "MULTI:aXbXcX", "NO_MATCH:hello"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-sub.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.5--re-sub.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["SINGLE:frame_002", "MULTI:aXbXcX", "NO_MATCH:hello"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SINGLE:{{ re_sub("frame_001", r"\d+", "002") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--path-absolute-relative.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--path-absolute-relative.test.yaml
@@ -6,10 +6,87 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "ABS_REL:[false]",
+              "ABS_URI:[true]",
+              "REL_TO_URI_T:[true]",
+              "REL_TO_URI_F:[false]",
+              "REL_TO_URI_SAME:[true]",
+              "REL_TO_MIX:[false]",
+              "RELATIVE_URI:[file.txt]",
+              "RELATIVE_URI_SAME:[.]",
+              "ABS_POSIX:[true]",
+              "ABS_WIN:[false]",
+              "ABS_UNC:[true]",
+              "REL_TO_POSIX_T:[true]",
+              "REL_TO_POSIX_F:[false]",
+              "REL_TO_UNC_T:[true]",
+              "REL_TO_UNC_F:[false]",
+              "RELATIVE_POSIX:[c/d]",
+              "RELATIVE_UNC:[dir/file]",
+              "RELATIVE_URI_NESTED:[a/b/c]",
+          ]
+          EXPECTED_WINDOWS = [
+              "ABS_REL:[false]",
+              "ABS_URI:[true]",
+              "REL_TO_URI_T:[true]",
+              "REL_TO_URI_F:[false]",
+              "REL_TO_URI_SAME:[true]",
+              "REL_TO_MIX:[false]",
+              "RELATIVE_URI:[file.txt]",
+              "RELATIVE_URI_SAME:[.]",
+              "ABS_POSIX:[false]",
+              "ABS_WIN:[true]",
+              "ABS_UNC:[true]",
+              "REL_TO_POSIX_T:[true]",
+              "REL_TO_POSIX_F:[false]",
+              "REL_TO_UNC_T:[true]",
+              "REL_TO_UNC_F:[false]",
+              "RELATIVE_POSIX:[c\\d]",
+              "RELATIVE_UNC:[dir\\file]",
+              "RELATIVE_URI_NESTED:[a\\b\\c]",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'ABS_POSIX:[{{ path("/a/b").is_absolute() }}]')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--path-absolute-relative.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--path-absolute-relative.test.yaml
@@ -9,83 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "ABS_REL:[false]",
-              "ABS_URI:[true]",
-              "REL_TO_URI_T:[true]",
-              "REL_TO_URI_F:[false]",
-              "REL_TO_URI_SAME:[true]",
-              "REL_TO_MIX:[false]",
-              "RELATIVE_URI:[file.txt]",
-              "RELATIVE_URI_SAME:[.]",
-              "ABS_POSIX:[true]",
-              "ABS_WIN:[false]",
-              "ABS_UNC:[true]",
-              "REL_TO_POSIX_T:[true]",
-              "REL_TO_POSIX_F:[false]",
-              "REL_TO_UNC_T:[true]",
-              "REL_TO_UNC_F:[false]",
-              "RELATIVE_POSIX:[c/d]",
-              "RELATIVE_UNC:[dir/file]",
-              "RELATIVE_URI_NESTED:[a/b/c]",
-          ]
-          EXPECTED_WINDOWS = [
-              "ABS_REL:[false]",
-              "ABS_URI:[true]",
-              "REL_TO_URI_T:[true]",
-              "REL_TO_URI_F:[false]",
-              "REL_TO_URI_SAME:[true]",
-              "REL_TO_MIX:[false]",
-              "RELATIVE_URI:[file.txt]",
-              "RELATIVE_URI_SAME:[.]",
-              "ABS_POSIX:[false]",
-              "ABS_WIN:[true]",
-              "ABS_UNC:[true]",
-              "REL_TO_POSIX_T:[true]",
-              "REL_TO_POSIX_F:[false]",
-              "REL_TO_UNC_T:[true]",
-              "REL_TO_UNC_F:[false]",
-              "RELATIVE_POSIX:[c\\d]",
-              "RELATIVE_UNC:[dir\\file]",
-              "RELATIVE_URI_NESTED:[a\\b\\c]",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["ABS_REL:[false]", "ABS_URI:[true]", "REL_TO_URI_T:[true]", "REL_TO_URI_F:[false]", "REL_TO_URI_SAME:[true]", "REL_TO_MIX:[false]", "RELATIVE_URI:[file.txt]", "RELATIVE_URI_SAME:[.]", "ABS_POSIX:[true]", "ABS_WIN:[false]", "ABS_UNC:[true]", "REL_TO_POSIX_T:[true]", "REL_TO_POSIX_F:[false]", "REL_TO_UNC_T:[true]", "REL_TO_UNC_F:[false]", "RELATIVE_POSIX:[c/d]", "RELATIVE_UNC:[dir/file]", "RELATIVE_URI_NESTED:[a/b/c]"], "expected_windows": ["ABS_REL:[false]", "ABS_URI:[true]", "REL_TO_URI_T:[true]", "REL_TO_URI_F:[false]", "REL_TO_URI_SAME:[true]", "REL_TO_MIX:[false]", "RELATIVE_URI:[file.txt]", "RELATIVE_URI_SAME:[.]", "ABS_POSIX:[false]", "ABS_WIN:[true]", "ABS_UNC:[true]", "REL_TO_POSIX_T:[true]", "REL_TO_POSIX_F:[false]", "REL_TO_UNC_T:[true]", "REL_TO_UNC_F:[false]", "RELATIVE_POSIX:[c\\d]", "RELATIVE_UNC:[dir\\file]", "RELATIVE_URI_NESTED:[a\\b\\c]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-cmd.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-cmd.test.yaml
@@ -29,60 +29,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "SIMPLE:hello",
-              "AMP:\"a & b\"",
-              "PIPE:\"x | y\"",
-              "CARET:\"a ^^ b\"",
-              "ANGLES:\"a < b > c\"",
-              "DQUOTE:\"say ^\"hi^\"\"",
-              "PARENS:\"(foo)\"",
-              "PCT:\"100%%\"",
-              "BANG:\"hello^^!\"",
-              "BANG_VAR:\"^^!PATH^^!\"",
-              "BANG_CARET:\"a ^^ b^^!\"",
-              "SPACES:\"hello world\"",
-              "NEWLINE_STRIPPED:ab",
-              "NEWLINE_R_STRIPPED:ab",
-              "NEWLINE_RN_STRIPPED:ab",
-              "LIST:echo \"a & b\"",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SIMPLE:hello", "AMP:\"a & b\"", "PIPE:\"x | y\"", "CARET:\"a ^^ b\"", "ANGLES:\"a < b > c\"", "DQUOTE:\"say ^\"hi^\"\"", "PARENS:\"(foo)\"", "PCT:\"100%%\"", "BANG:\"hello^^!\"", "BANG_VAR:\"^^!PATH^^!\"", "BANG_CARET:\"a ^^ b^^!\"", "SPACES:\"hello world\"", "NEWLINE_STRIPPED:ab", "NEWLINE_R_STRIPPED:ab", "NEWLINE_RN_STRIPPED:ab", "LIST:echo \"a & b\""]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-cmd.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-cmd.test.yaml
@@ -26,10 +26,64 @@ template:
       newline_rn = repr_cmd("a\r\nb")
     - "list_val = repr_cmd([\"echo\", \"a & b\"])"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "SIMPLE:hello",
+              "AMP:\"a & b\"",
+              "PIPE:\"x | y\"",
+              "CARET:\"a ^^ b\"",
+              "ANGLES:\"a < b > c\"",
+              "DQUOTE:\"say ^\"hi^\"\"",
+              "PARENS:\"(foo)\"",
+              "PCT:\"100%%\"",
+              "BANG:\"hello^^!\"",
+              "BANG_VAR:\"^^!PATH^^!\"",
+              "BANG_CARET:\"a ^^ b^^!\"",
+              "SPACES:\"hello world\"",
+              "NEWLINE_STRIPPED:ab",
+              "NEWLINE_R_STRIPPED:ab",
+              "NEWLINE_RN_STRIPPED:ab",
+              "LIST:echo \"a & b\"",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SIMPLE:{{ simple }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-json.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-json.test.yaml
@@ -18,52 +18,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "STR:\"hello\"",
-              "INT:42",
-              "FLOAT:3.14",
-              "BOOL_T:true",
-              "BOOL_F:false",
-              "NULL:null",
-              "LIST:[1, 2, 3]",
-              "RANGE:\"1-10\"",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["STR:\"hello\"", "INT:42", "FLOAT:3.14", "BOOL_T:true", "BOOL_F:false", "NULL:null", "LIST:[1, 2, 3]", "RANGE:\"1-10\""]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-json.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-json.test.yaml
@@ -15,10 +15,56 @@ template:
     - 'list_val = repr_json([1, 2, 3])'
     - "range_val = repr_json(range_expr(\"1-10\"))"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "STR:\"hello\"",
+              "INT:42",
+              "FLOAT:3.14",
+              "BOOL_T:true",
+              "BOOL_F:false",
+              "NULL:null",
+              "LIST:[1, 2, 3]",
+              "RANGE:\"1-10\"",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'STR:{{ str_val }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-pwsh.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-pwsh.test.yaml
@@ -19,53 +19,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "STR:'hello'",
-              "QUOTE:'it''s'",
-              "BOOL_T:$true",
-              "BOOL_F:$false",
-              "INT:42",
-              "FLOAT:3.14",
-              "PATH:'/tmp/out'",
-              "RANGE:'1-10'",
-              "LIST:@('a', 'b')",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["STR:'hello'", "QUOTE:'it''s'", "BOOL_T:$true", "BOOL_F:$false", "INT:42", "FLOAT:3.14", "PATH:'/tmp/out'", "RANGE:'1-10'", "LIST:@('a', 'b')"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-pwsh.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-pwsh.test.yaml
@@ -16,10 +16,57 @@ template:
     - "range_val = repr_pwsh(range_expr(\"1-10\"))"
     - "list_val = repr_pwsh([\"a\", \"b\"])"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "STR:'hello'",
+              "QUOTE:'it''s'",
+              "BOOL_T:$true",
+              "BOOL_F:$false",
+              "INT:42",
+              "FLOAT:3.14",
+              "PATH:'/tmp/out'",
+              "RANGE:'1-10'",
+              "LIST:@('a', 'b')",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r"STR:{{ str_val }}")

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-py.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-py.test.yaml
@@ -19,53 +19,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "STR:'hello'",
-              "INT:42",
-              "FLOAT:3.14",
-              "BOOL_T:True",
-              "BOOL_F:False",
-              "NULL:None",
-              "LIST:[1, 2]",
-              "PATH:'/tmp/out'",
-              "RANGE:'1-10'",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["STR:'hello'", "INT:42", "FLOAT:3.14", "BOOL_T:True", "BOOL_F:False", "NULL:None", "LIST:[1, 2]", "PATH:'/tmp/out'", "RANGE:'1-10'"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-py.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-py.test.yaml
@@ -16,10 +16,57 @@ template:
     - 'path_val = repr_py(path("/tmp/out"))'
     - "range_val = repr_py(range_expr(\"1-10\"))"
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "STR:'hello'",
+              "INT:42",
+              "FLOAT:3.14",
+              "BOOL_T:True",
+              "BOOL_F:False",
+              "NULL:None",
+              "LIST:[1, 2]",
+              "PATH:'/tmp/out'",
+              "RANGE:'1-10'",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r"STR:{{ str_val }}")

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--path-compound-suffix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--path-compound-suffix.test.yaml
@@ -12,10 +12,47 @@ template:
     - 'psuffixes = p.suffixes'
     - 'pstem = p.stem'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["SUFFIX:.gz", "SUFFIXES:[\".tar\", \".gz\"]", "STEM:backup.tar"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'SUFFIX:{{ psuffix }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--path-compound-suffix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--path-compound-suffix.test.yaml
@@ -15,43 +15,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["SUFFIX:.gz", "SUFFIXES:[\".tar\", \".gz\"]", "STEM:backup.tar"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["SUFFIX:.gz", "SUFFIXES:[\".tar\", \".gz\"]", "STEM:backup.tar"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--path-properties.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--path-properties.test.yaml
@@ -24,69 +24,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "NAME:scene.exr",
-              "STEM:scene",
-              "SUFFIX:.exr",
-              "SUFFIXES:[\".exr\"]",
-              "PARTS:[\"/\", \"mnt\", \"renders\", \"scene.exr\"]",
-              "NOEXT_SUFFIX:",
-              "NOEXT_SUFFIXES:[]",
-              "ROOT_NAME:0 chars",
-              "ROOT_PARENT_POSIX:/",
-              "ROOT_PARTS:[\"/\"]",
-              "PARENT:/mnt/renders",
-          ]
-          EXPECTED_WINDOWS = [
-              "NAME:scene.exr",
-              "STEM:scene",
-              "SUFFIX:.exr",
-              "SUFFIXES:[\".exr\"]",
-              "PARTS:[\"/\", \"mnt\", \"renders\", \"scene.exr\"]",
-              "NOEXT_SUFFIX:",
-              "NOEXT_SUFFIXES:[]",
-              "ROOT_NAME:0 chars",
-              "ROOT_PARENT_POSIX:/",
-              "ROOT_PARTS:[\"/\"]",
-              "PARENT:\\mnt\\renders",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["NAME:scene.exr", "STEM:scene", "SUFFIX:.exr", "SUFFIXES:[\".exr\"]", "PARTS:[\"/\", \"mnt\", \"renders\", \"scene.exr\"]", "NOEXT_SUFFIX:", "NOEXT_SUFFIXES:[]", "ROOT_NAME:0 chars", "ROOT_PARENT_POSIX:/", "ROOT_PARTS:[\"/\"]", "PARENT:/mnt/renders"], "expected_windows": ["NAME:scene.exr", "STEM:scene", "SUFFIX:.exr", "SUFFIXES:[\".exr\"]", "PARTS:[\"/\", \"mnt\", \"renders\", \"scene.exr\"]", "NOEXT_SUFFIX:", "NOEXT_SUFFIXES:[]", "ROOT_NAME:0 chars", "ROOT_PARENT_POSIX:/", "ROOT_PARTS:[\"/\"]", "PARENT:\\mnt\\renders"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--path-properties.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--path-properties.test.yaml
@@ -21,10 +21,73 @@ template:
     - 'root_parent = root.parent'
     - 'root_parts = root.parts'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "NAME:scene.exr",
+              "STEM:scene",
+              "SUFFIX:.exr",
+              "SUFFIXES:[\".exr\"]",
+              "PARTS:[\"/\", \"mnt\", \"renders\", \"scene.exr\"]",
+              "NOEXT_SUFFIX:",
+              "NOEXT_SUFFIXES:[]",
+              "ROOT_NAME:0 chars",
+              "ROOT_PARENT_POSIX:/",
+              "ROOT_PARTS:[\"/\"]",
+              "PARENT:/mnt/renders",
+          ]
+          EXPECTED_WINDOWS = [
+              "NAME:scene.exr",
+              "STEM:scene",
+              "SUFFIX:.exr",
+              "SUFFIXES:[\".exr\"]",
+              "PARTS:[\"/\", \"mnt\", \"renders\", \"scene.exr\"]",
+              "NOEXT_SUFFIX:",
+              "NOEXT_SUFFIXES:[]",
+              "ROOT_NAME:0 chars",
+              "ROOT_PARENT_POSIX:/",
+              "ROOT_PARTS:[\"/\"]",
+              "PARENT:\\mnt\\renders",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'NAME:{{ pname }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-host-context.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-host-context.test.yaml
@@ -9,10 +9,65 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "PARENT:s3://bucket/a/b",
+              "PARTS:[\"s3://bucket\", \"a\", \"b\"]",
+              "SCHEME_PRESERVED:s3://bucket/key",
+              "HTTPS:https://host/path/file.txt",
+              "HTTPS_PARENT:https://host/path",
+              "STR:s3://bucket/a/b/c.txt",
+              "JOIN:s3://bucket/a/b/c.txt",
+          ]
+          EXPECTED_WINDOWS = [
+              "PARENT:s3://bucket/a/b",
+              "PARTS:[\"s3://bucket\", \"a\", \"b\"]",
+              "SCHEME_PRESERVED:s3://bucket/key",
+              "HTTPS:https://host/path/file.txt",
+              "HTTPS_PARENT:https://host/path",
+              "STR:s3://bucket/a/b/c.txt",
+              "JOIN:s3://bucket/a/b/c.txt",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'STR:{{ path("s3://bucket/a/b/c.txt") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-host-context.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-host-context.test.yaml
@@ -12,61 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "PARENT:s3://bucket/a/b",
-              "PARTS:[\"s3://bucket\", \"a\", \"b\"]",
-              "SCHEME_PRESERVED:s3://bucket/key",
-              "HTTPS:https://host/path/file.txt",
-              "HTTPS_PARENT:https://host/path",
-              "STR:s3://bucket/a/b/c.txt",
-              "JOIN:s3://bucket/a/b/c.txt",
-          ]
-          EXPECTED_WINDOWS = [
-              "PARENT:s3://bucket/a/b",
-              "PARTS:[\"s3://bucket\", \"a\", \"b\"]",
-              "SCHEME_PRESERVED:s3://bucket/key",
-              "HTTPS:https://host/path/file.txt",
-              "HTTPS_PARENT:https://host/path",
-              "STR:s3://bucket/a/b/c.txt",
-              "JOIN:s3://bucket/a/b/c.txt",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["PARENT:s3://bucket/a/b", "PARTS:[\"s3://bucket\", \"a\", \"b\"]", "SCHEME_PRESERVED:s3://bucket/key", "HTTPS:https://host/path/file.txt", "HTTPS_PARENT:https://host/path", "STR:s3://bucket/a/b/c.txt", "JOIN:s3://bucket/a/b/c.txt"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-no-normalization.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-no-normalization.test.yaml
@@ -36,57 +36,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "P1_STR:s3://bucket/a//b/file.txt",
-              "P1_PARTS:[\"s3://bucket\", \"a\", \"\", \"b\", \"file.txt\"]",
-              "P1_NAME:file.txt",
-              "P1_PARENT:s3://bucket/a//b",
-              "P2_STR:s3://bucket/a///b",
-              "P2_PARTS:[\"s3://bucket\", \"a\", \"\", \"\", \"b\"]",
-              "P3_STR:s3://bucket/a/./b/../c",
-              "P3_PARTS:[\"s3://bucket\", \"a\", \".\", \"b\", \"..\", \"c\"]",
-              "P4_STR:s3://bucket/prefix/",
-              "P4_PARTS:[\"s3://bucket\", \"prefix\", \"\"]",
-              "P4_NAME:",
-              "RT_STR:s3://bucket/a//b/file.txt",
-              "RT_EQ:true",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["P1_STR:s3://bucket/a//b/file.txt", "P1_PARTS:[\"s3://bucket\", \"a\", \"\", \"b\", \"file.txt\"]", "P1_NAME:file.txt", "P1_PARENT:s3://bucket/a//b", "P2_STR:s3://bucket/a///b", "P2_PARTS:[\"s3://bucket\", \"a\", \"\", \"\", \"b\"]", "P3_STR:s3://bucket/a/./b/../c", "P3_PARTS:[\"s3://bucket\", \"a\", \".\", \"b\", \"..\", \"c\"]", "P4_STR:s3://bucket/prefix/", "P4_PARTS:[\"s3://bucket\", \"prefix\", \"\"]", "P4_NAME:", "RT_STR:s3://bucket/a//b/file.txt", "RT_EQ:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-no-normalization.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-no-normalization.test.yaml
@@ -33,10 +33,61 @@ template:
     - 'rt_str = string(rt)'
     - 'rt_eq = rt == p1'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "P1_STR:s3://bucket/a//b/file.txt",
+              "P1_PARTS:[\"s3://bucket\", \"a\", \"\", \"b\", \"file.txt\"]",
+              "P1_NAME:file.txt",
+              "P1_PARENT:s3://bucket/a//b",
+              "P2_STR:s3://bucket/a///b",
+              "P2_PARTS:[\"s3://bucket\", \"a\", \"\", \"\", \"b\"]",
+              "P3_STR:s3://bucket/a/./b/../c",
+              "P3_PARTS:[\"s3://bucket\", \"a\", \".\", \"b\", \"..\", \"c\"]",
+              "P4_STR:s3://bucket/prefix/",
+              "P4_PARTS:[\"s3://bucket\", \"prefix\", \"\"]",
+              "P4_NAME:",
+              "RT_STR:s3://bucket/a//b/file.txt",
+              "RT_EQ:true",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'P1_STR:{{ p1_str }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-properties.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-properties.test.yaml
@@ -42,63 +42,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "S3_NAME:teapot.obj",
-              "S3_STEM:teapot",
-              "S3_SUFFIX:.obj",
-              "S3_PARENT:s3://my-bucket/assets",
-              "S3_PARTS:[\"s3://my-bucket\", \"assets\", \"teapot.obj\"]",
-              "H_NAME:scene.tar.gz",
-              "H_STEM:scene.tar",
-              "H_SUFFIX:.gz",
-              "H_SUFFIXES:[\".tar\", \".gz\"]",
-              "H_PARENT:https://example.com/models",
-              "H_PARTS:[\"https://example.com\", \"models\", \"scene.tar.gz\"]",
-              "P2_PARENT1:s3://bucket/a",
-              "P2_PARENT2:s3://bucket",
-              "P2_ROOT:s3://bucket",
-              "BARE_NAME:",
-              "BARE_PARTS:[\"s3://bucket\"]",
-              "BARE_PARENT:s3://bucket",
-              "FSX_NAME:file.bin",
-              "FSX_PARTS:[\"fsx://vol-123\", \"data\", \"file.bin\"]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["S3_NAME:teapot.obj", "S3_STEM:teapot", "S3_SUFFIX:.obj", "S3_PARENT:s3://my-bucket/assets", "S3_PARTS:[\"s3://my-bucket\", \"assets\", \"teapot.obj\"]", "H_NAME:scene.tar.gz", "H_STEM:scene.tar", "H_SUFFIX:.gz", "H_SUFFIXES:[\".tar\", \".gz\"]", "H_PARENT:https://example.com/models", "H_PARTS:[\"https://example.com\", \"models\", \"scene.tar.gz\"]", "P2_PARENT1:s3://bucket/a", "P2_PARENT2:s3://bucket", "P2_ROOT:s3://bucket", "BARE_NAME:", "BARE_PARTS:[\"s3://bucket\"]", "BARE_PARENT:s3://bucket", "FSX_NAME:file.bin", "FSX_PARTS:[\"fsx://vol-123\", \"data\", \"file.bin\"]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-properties.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-properties.test.yaml
@@ -39,10 +39,67 @@ template:
     - 'fsx_name = fsx.name'
     - 'fsx_parts = fsx.parts'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "S3_NAME:teapot.obj",
+              "S3_STEM:teapot",
+              "S3_SUFFIX:.obj",
+              "S3_PARENT:s3://my-bucket/assets",
+              "S3_PARTS:[\"s3://my-bucket\", \"assets\", \"teapot.obj\"]",
+              "H_NAME:scene.tar.gz",
+              "H_STEM:scene.tar",
+              "H_SUFFIX:.gz",
+              "H_SUFFIXES:[\".tar\", \".gz\"]",
+              "H_PARENT:https://example.com/models",
+              "H_PARTS:[\"https://example.com\", \"models\", \"scene.tar.gz\"]",
+              "P2_PARENT1:s3://bucket/a",
+              "P2_PARENT2:s3://bucket",
+              "P2_ROOT:s3://bucket",
+              "BARE_NAME:",
+              "BARE_PARTS:[\"s3://bucket\"]",
+              "BARE_PARENT:s3://bucket",
+              "FSX_NAME:file.bin",
+              "FSX_PARTS:[\"fsx://vol-123\", \"data\", \"file.bin\"]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'S3_NAME:{{ s3_name }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-scheme-detection.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-scheme-detection.test.yaml
@@ -23,71 +23,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "S3:s3://bucket/key",
-              "S3_PARTS:[\"s3://bucket\", \"key\"]",
-              "HTTPS:https://host/path",
-              "HTTPS_PARTS:[\"https://host\", \"path\"]",
-              "FSX:fsx://vol/data",
-              "FSX_PARTS:[\"fsx://vol\", \"data\"]",
-              "CUSTOM:my-scheme+2://server/path",
-              "CUSTOM_PARTS:[\"my-scheme+2://server\", \"path\"]",
-              "POSIX_ABS:/mnt/data/file.txt",
-              "POSIX_ABS_PARTS:[\"/\", \"mnt\", \"data\", \"file.txt\"]",
-              "POSIX_REL:relative/path",
-              "COLON:/mnt/c:/data",
-          ]
-          EXPECTED_WINDOWS = [
-              "S3:s3://bucket/key",
-              "S3_PARTS:[\"s3://bucket\", \"key\"]",
-              "HTTPS:https://host/path",
-              "HTTPS_PARTS:[\"https://host\", \"path\"]",
-              "FSX:fsx://vol/data",
-              "FSX_PARTS:[\"fsx://vol\", \"data\"]",
-              "CUSTOM:my-scheme+2://server/path",
-              "CUSTOM_PARTS:[\"my-scheme+2://server\", \"path\"]",
-              "POSIX_ABS:\\mnt\\data\\file.txt",
-              "POSIX_ABS_PARTS:[\"\\\", \"mnt\", \"data\", \"file.txt\"]",
-              "POSIX_REL:relative\\path",
-              "COLON:\\mnt\\c:\\data",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["S3:s3://bucket/key", "S3_PARTS:[\"s3://bucket\", \"key\"]", "HTTPS:https://host/path", "HTTPS_PARTS:[\"https://host\", \"path\"]", "FSX:fsx://vol/data", "FSX_PARTS:[\"fsx://vol\", \"data\"]", "CUSTOM:my-scheme+2://server/path", "CUSTOM_PARTS:[\"my-scheme+2://server\", \"path\"]", "POSIX_ABS:/mnt/data/file.txt", "POSIX_ABS_PARTS:[\"/\", \"mnt\", \"data\", \"file.txt\"]", "POSIX_REL:relative/path", "COLON:/mnt/c:/data"], "expected_windows": ["S3:s3://bucket/key", "S3_PARTS:[\"s3://bucket\", \"key\"]", "HTTPS:https://host/path", "HTTPS_PARTS:[\"https://host\", \"path\"]", "FSX:fsx://vol/data", "FSX_PARTS:[\"fsx://vol\", \"data\"]", "CUSTOM:my-scheme+2://server/path", "CUSTOM_PARTS:[\"my-scheme+2://server\", \"path\"]", "POSIX_ABS:\\mnt\\data\\file.txt", "POSIX_ABS_PARTS:[\"\\\", \"mnt\", \"data\", \"file.txt\"]", "POSIX_REL:relative\\path", "COLON:\\mnt\\c:\\data"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-scheme-detection.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-scheme-detection.test.yaml
@@ -20,10 +20,75 @@ template:
     # --- Edge case: colon in path but not a URI ---
     - 'colon_path = path("/mnt/c:/data")'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "S3:s3://bucket/key",
+              "S3_PARTS:[\"s3://bucket\", \"key\"]",
+              "HTTPS:https://host/path",
+              "HTTPS_PARTS:[\"https://host\", \"path\"]",
+              "FSX:fsx://vol/data",
+              "FSX_PARTS:[\"fsx://vol\", \"data\"]",
+              "CUSTOM:my-scheme+2://server/path",
+              "CUSTOM_PARTS:[\"my-scheme+2://server\", \"path\"]",
+              "POSIX_ABS:/mnt/data/file.txt",
+              "POSIX_ABS_PARTS:[\"/\", \"mnt\", \"data\", \"file.txt\"]",
+              "POSIX_REL:relative/path",
+              "COLON:/mnt/c:/data",
+          ]
+          EXPECTED_WINDOWS = [
+              "S3:s3://bucket/key",
+              "S3_PARTS:[\"s3://bucket\", \"key\"]",
+              "HTTPS:https://host/path",
+              "HTTPS_PARTS:[\"https://host\", \"path\"]",
+              "FSX:fsx://vol/data",
+              "FSX_PARTS:[\"fsx://vol\", \"data\"]",
+              "CUSTOM:my-scheme+2://server/path",
+              "CUSTOM_PARTS:[\"my-scheme+2://server\", \"path\"]",
+              "POSIX_ABS:\\mnt\\data\\file.txt",
+              "POSIX_ABS_PARTS:[\"\\\", \"mnt\", \"data\", \"file.txt\"]",
+              "POSIX_REL:relative\\path",
+              "COLON:\\mnt\\c:\\data",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'S3:{{ s3 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-unmapped.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-unmapped.test.yaml
@@ -13,10 +13,56 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "VALUE:s3://my-bucket/assets/teapot.obj",
+              "NAME:teapot.obj",
+              "STEM:teapot",
+              "SUFFIX:.obj",
+              "PARENT:s3://my-bucket/assets",
+              "PARTS:[\"s3://my-bucket\", \"assets\", \"teapot.obj\"]",
+              "WITH_SUFFIX:s3://my-bucket/assets/teapot.png",
+              "JOIN:s3://my-bucket/assets/other.obj",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'VALUE:{{ Param.InputFile }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-unmapped.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-unmapped.test.yaml
@@ -16,52 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "VALUE:s3://my-bucket/assets/teapot.obj",
-              "NAME:teapot.obj",
-              "STEM:teapot",
-              "SUFFIX:.obj",
-              "PARENT:s3://my-bucket/assets",
-              "PARTS:[\"s3://my-bucket\", \"assets\", \"teapot.obj\"]",
-              "WITH_SUFFIX:s3://my-bucket/assets/teapot.png",
-              "JOIN:s3://my-bucket/assets/other.obj",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["VALUE:s3://my-bucket/assets/teapot.obj", "NAME:teapot.obj", "STEM:teapot", "SUFFIX:.obj", "PARENT:s3://my-bucket/assets", "PARTS:[\"s3://my-bucket\", \"assets\", \"teapot.obj\"]", "WITH_SUFFIX:s3://my-bucket/assets/teapot.png", "JOIN:s3://my-bucket/assets/other.obj"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--apply-path-mapping.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--apply-path-mapping.test.yaml
@@ -6,10 +6,59 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "POSIX_MAPPED:/local/cache/project/scene.exr",
+              "POSIX_UNMAPPED:/other/path/file.txt",
+              "WIN_MAPPED:/data/assets/textures/wood.png",
+              "WIN_UNMAPPED:E:\\other\\file.txt",
+          ]
+          EXPECTED_WINDOWS = [
+              "POSIX_MAPPED:\\local\\cache\\project\\scene.exr",
+              "POSIX_UNMAPPED:\\other\\path\\file.txt",
+              "WIN_MAPPED:\\data\\assets\\textures\\wood.png",
+              "WIN_UNMAPPED:E:\\other\\file.txt",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'POSIX_MAPPED:{{ apply_path_mapping("/mnt/shared/project/scene.exr") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--apply-path-mapping.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--apply-path-mapping.test.yaml
@@ -9,55 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "POSIX_MAPPED:/local/cache/project/scene.exr",
-              "POSIX_UNMAPPED:/other/path/file.txt",
-              "WIN_MAPPED:/data/assets/textures/wood.png",
-              "WIN_UNMAPPED:E:\\other\\file.txt",
-          ]
-          EXPECTED_WINDOWS = [
-              "POSIX_MAPPED:\\local\\cache\\project\\scene.exr",
-              "POSIX_UNMAPPED:\\other\\path\\file.txt",
-              "WIN_MAPPED:\\data\\assets\\textures\\wood.png",
-              "WIN_UNMAPPED:E:\\other\\file.txt",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["POSIX_MAPPED:/local/cache/project/scene.exr", "POSIX_UNMAPPED:/other/path/file.txt", "WIN_MAPPED:/data/assets/textures/wood.png", "WIN_UNMAPPED:E:\\other\\file.txt"], "expected_windows": ["POSIX_MAPPED:\\local\\cache\\project\\scene.exr", "POSIX_UNMAPPED:\\other\\path\\file.txt", "WIN_MAPPED:\\data\\assets\\textures\\wood.png", "WIN_UNMAPPED:E:\\other\\file.txt"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--as-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--as-posix.test.yaml
@@ -9,10 +9,47 @@ template:
     - 'posix = as_posix(path("/mnt/renders/scene.exr"))'
     - 'relative = as_posix(path("a/b/c"))'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["ABS:/mnt/renders/scene.exr", "REL:a/b/c"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'ABS:{{ posix }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--as-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--as-posix.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["ABS:/mnt/renders/scene.exr", "REL:a/b/c"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ABS:/mnt/renders/scene.exr", "REL:a/b/c"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--path-construction.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--path-construction.test.yaml
@@ -10,10 +10,49 @@ template:
     - 'from_parts = path(["a", "b", "c"])'
     - 'from_abs_parts = path(["/", "usr", "local"])'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = ["STR:/a/b", "PARTS:a/b/c", "ABS_PARTS:/usr/local"]
+          EXPECTED_WINDOWS = ["STR:\\a\\b", "PARTS:a\\b\\c", "ABS_PARTS:\\usr\\local"]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'STR:{{ from_str }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--path-construction.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--path-construction.test.yaml
@@ -13,45 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = ["STR:/a/b", "PARTS:a/b/c", "ABS_PARTS:/usr/local"]
-          EXPECTED_WINDOWS = ["STR:\\a\\b", "PARTS:a\\b\\c", "ABS_PARTS:\\usr\\local"]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["STR:/a/b", "PARTS:a/b/c", "ABS_PARTS:/usr/local"], "expected_windows": ["STR:\\a\\b", "PARTS:a\\b\\c", "ABS_PARTS:\\usr\\local"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-explicit-values-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-explicit-values-posix.test.yaml
@@ -18,10 +18,67 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "S3_RAW:s3://my-bucket/assets/teapot.obj",
+              "S3_NAME:teapot.obj",
+              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
+              "UNMAPPED_RAW:fsx://vol/data/file.bin",
+              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
+              "UNMAPPED_NAME:file.bin",
+              "S3_MAPPED:/local/assets/teapot.obj",
+              "HTTP_MAPPED:/cache/models/scene.obj",
+          ]
+          EXPECTED_WINDOWS = [
+              "S3_RAW:s3://my-bucket/assets/teapot.obj",
+              "S3_NAME:teapot.obj",
+              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
+              "UNMAPPED_RAW:fsx://vol/data/file.bin",
+              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
+              "UNMAPPED_NAME:file.bin",
+              "S3_MAPPED:\\local\\assets\\teapot.obj",
+              "HTTP_MAPPED:\\cache\\models\\scene.obj",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'S3_RAW:{{ RawParam.S3File }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-explicit-values-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-explicit-values-posix.test.yaml
@@ -21,63 +21,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "S3_RAW:s3://my-bucket/assets/teapot.obj",
-              "S3_NAME:teapot.obj",
-              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
-              "UNMAPPED_RAW:fsx://vol/data/file.bin",
-              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
-              "UNMAPPED_NAME:file.bin",
-              "S3_MAPPED:/local/assets/teapot.obj",
-              "HTTP_MAPPED:/cache/models/scene.obj",
-          ]
-          EXPECTED_WINDOWS = [
-              "S3_RAW:s3://my-bucket/assets/teapot.obj",
-              "S3_NAME:teapot.obj",
-              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
-              "UNMAPPED_RAW:fsx://vol/data/file.bin",
-              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
-              "UNMAPPED_NAME:file.bin",
-              "S3_MAPPED:\\local\\assets\\teapot.obj",
-              "HTTP_MAPPED:\\cache\\models\\scene.obj",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["S3_RAW:s3://my-bucket/assets/teapot.obj", "S3_NAME:teapot.obj", "HTTP_RAW:https://cdn.example.com/models/scene.obj", "UNMAPPED_RAW:fsx://vol/data/file.bin", "UNMAPPED_VALUE:fsx://vol/data/file.bin", "UNMAPPED_NAME:file.bin", "S3_MAPPED:/local/assets/teapot.obj", "HTTP_MAPPED:/cache/models/scene.obj"], "expected_windows": ["S3_RAW:s3://my-bucket/assets/teapot.obj", "S3_NAME:teapot.obj", "HTTP_RAW:https://cdn.example.com/models/scene.obj", "UNMAPPED_RAW:fsx://vol/data/file.bin", "UNMAPPED_VALUE:fsx://vol/data/file.bin", "UNMAPPED_NAME:file.bin", "S3_MAPPED:\\local\\assets\\teapot.obj", "HTTP_MAPPED:\\cache\\models\\scene.obj"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-explicit-values-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-explicit-values-windows.test.yaml
@@ -21,52 +21,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "S3_RAW:s3://my-bucket/assets/teapot.obj",
-              "S3_MAPPED:E:\\local\\assets\\teapot.obj",
-              "S3_NAME:teapot.obj",
-              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
-              "HTTP_MAPPED:E:\\cache\\models\\scene.obj",
-              "UNMAPPED_RAW:fsx://vol/data/file.bin",
-              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
-              "UNMAPPED_NAME:file.bin",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["S3_RAW:s3://my-bucket/assets/teapot.obj", "S3_MAPPED:E:\\local\\assets\\teapot.obj", "S3_NAME:teapot.obj", "HTTP_RAW:https://cdn.example.com/models/scene.obj", "HTTP_MAPPED:E:\\cache\\models\\scene.obj", "UNMAPPED_RAW:fsx://vol/data/file.bin", "UNMAPPED_VALUE:fsx://vol/data/file.bin", "UNMAPPED_NAME:file.bin"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-explicit-values-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-explicit-values-windows.test.yaml
@@ -18,10 +18,56 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "S3_RAW:s3://my-bucket/assets/teapot.obj",
+              "S3_MAPPED:E:\\local\\assets\\teapot.obj",
+              "S3_NAME:teapot.obj",
+              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
+              "HTTP_MAPPED:E:\\cache\\models\\scene.obj",
+              "UNMAPPED_RAW:fsx://vol/data/file.bin",
+              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
+              "UNMAPPED_NAME:file.bin",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'S3_RAW:{{ RawParam.S3File }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-implicit-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-implicit-mapping-posix.test.yaml
@@ -22,10 +22,73 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "S3_RAW:s3://my-bucket/assets/teapot.obj",
+              "S3_NAME:teapot.obj",
+              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
+              "HTTP_NAME:scene.obj",
+              "UNMAPPED_RAW:fsx://vol/data/file.bin",
+              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
+              "UNMAPPED_NAME:file.bin",
+              "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]",
+              "S3_MAPPED:/local/assets/teapot.obj",
+              "S3_PARENT:/local/assets",
+              "HTTP_MAPPED:/cache/models/scene.obj",
+          ]
+          EXPECTED_WINDOWS = [
+              "S3_RAW:s3://my-bucket/assets/teapot.obj",
+              "S3_NAME:teapot.obj",
+              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
+              "HTTP_NAME:scene.obj",
+              "UNMAPPED_RAW:fsx://vol/data/file.bin",
+              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
+              "UNMAPPED_NAME:file.bin",
+              "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]",
+              "S3_MAPPED:\\local\\assets\\teapot.obj",
+              "S3_PARENT:\\local\\assets",
+              "HTTP_MAPPED:\\cache\\models\\scene.obj",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'S3_RAW:{{ RawParam.S3File }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-implicit-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-implicit-mapping-posix.test.yaml
@@ -25,69 +25,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "S3_RAW:s3://my-bucket/assets/teapot.obj",
-              "S3_NAME:teapot.obj",
-              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
-              "HTTP_NAME:scene.obj",
-              "UNMAPPED_RAW:fsx://vol/data/file.bin",
-              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
-              "UNMAPPED_NAME:file.bin",
-              "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]",
-              "S3_MAPPED:/local/assets/teapot.obj",
-              "S3_PARENT:/local/assets",
-              "HTTP_MAPPED:/cache/models/scene.obj",
-          ]
-          EXPECTED_WINDOWS = [
-              "S3_RAW:s3://my-bucket/assets/teapot.obj",
-              "S3_NAME:teapot.obj",
-              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
-              "HTTP_NAME:scene.obj",
-              "UNMAPPED_RAW:fsx://vol/data/file.bin",
-              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
-              "UNMAPPED_NAME:file.bin",
-              "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]",
-              "S3_MAPPED:\\local\\assets\\teapot.obj",
-              "S3_PARENT:\\local\\assets",
-              "HTTP_MAPPED:\\cache\\models\\scene.obj",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["S3_RAW:s3://my-bucket/assets/teapot.obj", "S3_NAME:teapot.obj", "HTTP_RAW:https://cdn.example.com/models/scene.obj", "HTTP_NAME:scene.obj", "UNMAPPED_RAW:fsx://vol/data/file.bin", "UNMAPPED_VALUE:fsx://vol/data/file.bin", "UNMAPPED_NAME:file.bin", "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]", "S3_MAPPED:/local/assets/teapot.obj", "S3_PARENT:/local/assets", "HTTP_MAPPED:/cache/models/scene.obj"], "expected_windows": ["S3_RAW:s3://my-bucket/assets/teapot.obj", "S3_NAME:teapot.obj", "HTTP_RAW:https://cdn.example.com/models/scene.obj", "HTTP_NAME:scene.obj", "UNMAPPED_RAW:fsx://vol/data/file.bin", "UNMAPPED_VALUE:fsx://vol/data/file.bin", "UNMAPPED_NAME:file.bin", "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]", "S3_MAPPED:\\local\\assets\\teapot.obj", "S3_PARENT:\\local\\assets", "HTTP_MAPPED:\\cache\\models\\scene.obj"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-implicit-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-implicit-mapping-windows.test.yaml
@@ -25,55 +25,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "S3_RAW:s3://my-bucket/assets/teapot.obj",
-              "S3_MAPPED:E:\\local\\assets\\teapot.obj",
-              "S3_NAME:teapot.obj",
-              "S3_PARENT:E:\\local\\assets",
-              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
-              "HTTP_MAPPED:E:\\cache\\models\\scene.obj",
-              "HTTP_NAME:scene.obj",
-              "UNMAPPED_RAW:fsx://vol/data/file.bin",
-              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
-              "UNMAPPED_NAME:file.bin",
-              "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["S3_RAW:s3://my-bucket/assets/teapot.obj", "S3_MAPPED:E:\\local\\assets\\teapot.obj", "S3_NAME:teapot.obj", "S3_PARENT:E:\\local\\assets", "HTTP_RAW:https://cdn.example.com/models/scene.obj", "HTTP_MAPPED:E:\\cache\\models\\scene.obj", "HTTP_NAME:scene.obj", "UNMAPPED_RAW:fsx://vol/data/file.bin", "UNMAPPED_VALUE:fsx://vol/data/file.bin", "UNMAPPED_NAME:file.bin", "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-implicit-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-param-implicit-mapping-windows.test.yaml
@@ -22,10 +22,59 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "S3_RAW:s3://my-bucket/assets/teapot.obj",
+              "S3_MAPPED:E:\\local\\assets\\teapot.obj",
+              "S3_NAME:teapot.obj",
+              "S3_PARENT:E:\\local\\assets",
+              "HTTP_RAW:https://cdn.example.com/models/scene.obj",
+              "HTTP_MAPPED:E:\\cache\\models\\scene.obj",
+              "HTTP_NAME:scene.obj",
+              "UNMAPPED_RAW:fsx://vol/data/file.bin",
+              "UNMAPPED_VALUE:fsx://vol/data/file.bin",
+              "UNMAPPED_NAME:file.bin",
+              "UNMAPPED_PARTS:[\"fsx://vol\", \"data\", \"file.bin\"]",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'S3_RAW:{{ RawParam.S3File }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-mapping-posix.test.yaml
@@ -14,10 +14,59 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "MAPPED_NAME:teapot.obj",
+              "RAW:s3://my-bucket/assets/teapot.obj",
+              "MAPPED:/mnt/shared/assets/teapot.obj",
+              "MAPPED_PARENT:/mnt/shared/assets",
+          ]
+          EXPECTED_WINDOWS = [
+              "MAPPED_NAME:teapot.obj",
+              "RAW:s3://my-bucket/assets/teapot.obj",
+              "MAPPED:\\mnt\\shared\\assets\\teapot.obj",
+              "MAPPED_PARENT:\\mnt\\shared\\assets",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'MAPPED:{{ Param.InputFile }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-mapping-posix.test.yaml
@@ -17,55 +17,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "MAPPED_NAME:teapot.obj",
-              "RAW:s3://my-bucket/assets/teapot.obj",
-              "MAPPED:/mnt/shared/assets/teapot.obj",
-              "MAPPED_PARENT:/mnt/shared/assets",
-          ]
-          EXPECTED_WINDOWS = [
-              "MAPPED_NAME:teapot.obj",
-              "RAW:s3://my-bucket/assets/teapot.obj",
-              "MAPPED:\\mnt\\shared\\assets\\teapot.obj",
-              "MAPPED_PARENT:\\mnt\\shared\\assets",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["MAPPED_NAME:teapot.obj", "RAW:s3://my-bucket/assets/teapot.obj", "MAPPED:/mnt/shared/assets/teapot.obj", "MAPPED_PARENT:/mnt/shared/assets"], "expected_windows": ["MAPPED_NAME:teapot.obj", "RAW:s3://my-bucket/assets/teapot.obj", "MAPPED:\\mnt\\shared\\assets\\teapot.obj", "MAPPED_PARENT:\\mnt\\shared\\assets"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-mapping-windows.test.yaml
@@ -17,48 +17,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "MAPPED:E:\\shared\\assets\\teapot.obj",
-              "MAPPED_NAME:teapot.obj",
-              "MAPPED_PARENT:E:\\shared\\assets",
-              "RAW:s3://my-bucket/assets/teapot.obj",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MAPPED:E:\\shared\\assets\\teapot.obj", "MAPPED_NAME:teapot.obj", "MAPPED_PARENT:E:\\shared\\assets", "RAW:s3://my-bucket/assets/teapot.obj"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-mapping-windows.test.yaml
@@ -14,10 +14,52 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "MAPPED:E:\\shared\\assets\\teapot.obj",
+              "MAPPED_NAME:teapot.obj",
+              "MAPPED_PARENT:E:\\shared\\assets",
+              "RAW:s3://my-bucket/assets/teapot.obj",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'MAPPED:{{ Param.InputFile }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-ops.test.yaml
@@ -45,10 +45,60 @@ template:
     - 'wnum = path("s3://bucket/renders/shot_####.exr").with_number(42)'
     - 'wnum_str = string(wnum)'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "JOINED:s3://bucket/assets/subdir/file.obj",
+              "MULTI:s3://bucket/a/b/c.txt",
+              "ABS_REPLACE:/local/path",
+              "CONCAT:s3://bucket/file.txt",
+              "FROM_STR:https://host/a/b",
+              "FROM_PARTS:s3://bucket/dir/file.obj",
+              "FROM_DBL:s3://bucket/a//b",
+              "WITH_SUFFIX:s3://bucket/renders/scene.png",
+              "WITH_NAME:s3://bucket/renders/other.obj",
+              "WITH_STEM:s3://bucket/renders/final.exr",
+              "AS_POSIX:s3://bucket/a/b",
+              "WITH_NUMBER:s3://bucket/renders/shot_0042.exr",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'JOINED:{{ joined_str }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-ops.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-path-ops.test.yaml
@@ -48,56 +48,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "JOINED:s3://bucket/assets/subdir/file.obj",
-              "MULTI:s3://bucket/a/b/c.txt",
-              "ABS_REPLACE:/local/path",
-              "CONCAT:s3://bucket/file.txt",
-              "FROM_STR:https://host/a/b",
-              "FROM_PARTS:s3://bucket/dir/file.obj",
-              "FROM_DBL:s3://bucket/a//b",
-              "WITH_SUFFIX:s3://bucket/renders/scene.png",
-              "WITH_NAME:s3://bucket/renders/other.obj",
-              "WITH_STEM:s3://bucket/renders/final.exr",
-              "AS_POSIX:s3://bucket/a/b",
-              "WITH_NUMBER:s3://bucket/renders/shot_0042.exr",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["JOINED:s3://bucket/assets/subdir/file.obj", "MULTI:s3://bucket/a/b/c.txt", "ABS_REPLACE:/local/path", "CONCAT:s3://bucket/file.txt", "FROM_STR:https://host/a/b", "FROM_PARTS:s3://bucket/dir/file.obj", "FROM_DBL:s3://bucket/a//b", "WITH_SUFFIX:s3://bucket/renders/scene.png", "WITH_NAME:s3://bucket/renders/other.obj", "WITH_STEM:s3://bucket/renders/final.exr", "AS_POSIX:s3://bucket/a/b", "WITH_NUMBER:s3://bucket/renders/shot_0042.exr"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-source-path-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-source-path-mapping-posix.test.yaml
@@ -13,65 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj",
-              "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj",
-              "HTTPS_NOMATCH:https://other.com/models/scene.obj",
-              "UNMAPPED:fsx://vol/data/file.bin",
-              "S3_MATCH:/local/assets/teapot.obj",
-              "S3_EXACT:/local/assets",
-              "S3_NESTED:/local/assets/sub/dir/file.exr",
-              "HTTPS_MATCH:/cache/models/scene.obj",
-              "POSIX_STILL_WORKS:/local/shared/project/file.exr",
-          ]
-          EXPECTED_WINDOWS = [
-              "S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj",
-              "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj",
-              "HTTPS_NOMATCH:https://other.com/models/scene.obj",
-              "UNMAPPED:fsx://vol/data/file.bin",
-              "S3_MATCH:\\local\\assets\\teapot.obj",
-              "S3_EXACT:\\local\\assets",
-              "S3_NESTED:\\local\\assets\\sub\\dir\\file.exr",
-              "HTTPS_MATCH:\\cache\\models\\scene.obj",
-              "POSIX_STILL_WORKS:\\local\\shared\\project\\file.exr",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj", "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj", "HTTPS_NOMATCH:https://other.com/models/scene.obj", "UNMAPPED:fsx://vol/data/file.bin", "S3_MATCH:/local/assets/teapot.obj", "S3_EXACT:/local/assets", "S3_NESTED:/local/assets/sub/dir/file.exr", "HTTPS_MATCH:/cache/models/scene.obj", "POSIX_STILL_WORKS:/local/shared/project/file.exr"], "expected_windows": ["S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj", "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj", "HTTPS_NOMATCH:https://other.com/models/scene.obj", "UNMAPPED:fsx://vol/data/file.bin", "S3_MATCH:\\local\\assets\\teapot.obj", "S3_EXACT:\\local\\assets", "S3_NESTED:\\local\\assets\\sub\\dir\\file.exr", "HTTPS_MATCH:\\cache\\models\\scene.obj", "POSIX_STILL_WORKS:\\local\\shared\\project\\file.exr"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-source-path-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-source-path-mapping-posix.test.yaml
@@ -10,10 +10,69 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj",
+              "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj",
+              "HTTPS_NOMATCH:https://other.com/models/scene.obj",
+              "UNMAPPED:fsx://vol/data/file.bin",
+              "S3_MATCH:/local/assets/teapot.obj",
+              "S3_EXACT:/local/assets",
+              "S3_NESTED:/local/assets/sub/dir/file.exr",
+              "HTTPS_MATCH:/cache/models/scene.obj",
+              "POSIX_STILL_WORKS:/local/shared/project/file.exr",
+          ]
+          EXPECTED_WINDOWS = [
+              "S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj",
+              "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj",
+              "HTTPS_NOMATCH:https://other.com/models/scene.obj",
+              "UNMAPPED:fsx://vol/data/file.bin",
+              "S3_MATCH:\\local\\assets\\teapot.obj",
+              "S3_EXACT:\\local\\assets",
+              "S3_NESTED:\\local\\assets\\sub\\dir\\file.exr",
+              "HTTPS_MATCH:\\cache\\models\\scene.obj",
+              "POSIX_STILL_WORKS:\\local\\shared\\project\\file.exr",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'S3_MATCH:{{ apply_path_mapping("s3://my-bucket/assets/teapot.obj") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-source-path-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-source-path-mapping-windows.test.yaml
@@ -13,53 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "S3_MATCH:E:\\local\\assets\\teapot.obj",
-              "S3_EXACT:E:\\local\\assets",
-              "S3_NESTED:E:\\local\\assets\\sub\\dir\\file.exr",
-              "S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj",
-              "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj",
-              "HTTPS_MATCH:E:\\cache\\models\\scene.obj",
-              "HTTPS_NOMATCH:https://other.com/models/scene.obj",
-              "WINDOWS_STILL_WORKS:E:\\local\\shared\\project\\file.exr",
-              "UNMAPPED:fsx://vol/data/file.bin",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["S3_MATCH:E:\\local\\assets\\teapot.obj", "S3_EXACT:E:\\local\\assets", "S3_NESTED:E:\\local\\assets\\sub\\dir\\file.exr", "S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj", "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj", "HTTPS_MATCH:E:\\cache\\models\\scene.obj", "HTTPS_NOMATCH:https://other.com/models/scene.obj", "WINDOWS_STILL_WORKS:E:\\local\\shared\\project\\file.exr", "UNMAPPED:fsx://vol/data/file.bin"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-source-path-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--uri-source-path-mapping-windows.test.yaml
@@ -10,10 +10,57 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "S3_MATCH:E:\\local\\assets\\teapot.obj",
+              "S3_EXACT:E:\\local\\assets",
+              "S3_NESTED:E:\\local\\assets\\sub\\dir\\file.exr",
+              "S3_NOMATCH_BUCKET:s3://other-bucket/assets/file.obj",
+              "S3_NOMATCH_PREFIX:s3://my-bucket/assets2/file.obj",
+              "HTTPS_MATCH:E:\\cache\\models\\scene.obj",
+              "HTTPS_NOMATCH:https://other.com/models/scene.obj",
+              "WINDOWS_STILL_WORKS:E:\\local\\shared\\project\\file.exr",
+              "UNMAPPED:fsx://vol/data/file.bin",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'S3_MATCH:{{ apply_path_mapping("s3://my-bucket/assets/teapot.obj") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--with-name-stem-suffix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--with-name-stem-suffix.test.yaml
@@ -13,10 +13,59 @@ template:
     - 'wsuffix = with_suffix(p, ".png")'
     - 'nosuffix = with_suffix(p, "")'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "NAME:/renders/other.png",
+              "STEM:/renders/final.exr",
+              "SUFFIX:/renders/scene.png",
+              "NOSUFFIX:/renders/scene",
+          ]
+          EXPECTED_WINDOWS = [
+              "NAME:\\renders\\other.png",
+              "STEM:\\renders\\final.exr",
+              "SUFFIX:\\renders\\scene.png",
+              "NOSUFFIX:\\renders\\scene",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'NAME:{{ wname }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--with-name-stem-suffix.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--with-name-stem-suffix.test.yaml
@@ -16,55 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "NAME:/renders/other.png",
-              "STEM:/renders/final.exr",
-              "SUFFIX:/renders/scene.png",
-              "NOSUFFIX:/renders/scene",
-          ]
-          EXPECTED_WINDOWS = [
-              "NAME:\\renders\\other.png",
-              "STEM:\\renders\\final.exr",
-              "SUFFIX:\\renders\\scene.png",
-              "NOSUFFIX:\\renders\\scene",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["NAME:/renders/other.png", "STEM:/renders/final.exr", "SUFFIX:/renders/scene.png", "NOSUFFIX:/renders/scene"], "expected_windows": ["NAME:\\renders\\other.png", "STEM:\\renders\\final.exr", "SUFFIX:\\renders\\scene.png", "NOSUFFIX:\\renders\\scene"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--with-number.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--with-number.test.yaml
@@ -23,10 +23,83 @@ template:
     - 'mixed_hash_after_printf = with_number(path("/out/f_%d_abc_###.exr"), 42)'
     - 'mixed_digits_after_printf = with_number(path("/out/file_%04d_003.exr"), 72)'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = [
+              "STR:file_072.exr",
+              "DIGITS:/out/file_072.exr",
+              "PRINTF_BARE:/out/file_72.exr",
+              "PRINTF_PAD:/out/file_0072.exr",
+              "HASH4:/out/file_0072.exr",
+              "HASH6:/out/file_000072.exr",
+              "OVERFLOW:/out/file_10000.exr",
+              "NO_PATTERN:/out/render_0072.exr",
+              "NEG_DIGITS:/out/file_-01.exr",
+              "NEG_PRINTF:/out/file_-001.exr",
+              "NEG_HASH:/out/file_-001.exr",
+              "MULTI_EXT:/out/render.0072.exr",
+              "VFX_VERSION:/out/file.v2.072.exr",
+              "DOT_ONLY:/out/file_0072.001",
+              "MIXED_HP:/out/f_%d_abc_042.exr",
+              "MIXED_DP:/out/file_%04d_072.exr",
+          ]
+          EXPECTED_WINDOWS = [
+              "STR:file_072.exr",
+              "DIGITS:\\out\\file_072.exr",
+              "PRINTF_BARE:\\out\\file_72.exr",
+              "PRINTF_PAD:\\out\\file_0072.exr",
+              "HASH4:\\out\\file_0072.exr",
+              "HASH6:\\out\\file_000072.exr",
+              "OVERFLOW:\\out\\file_10000.exr",
+              "NO_PATTERN:\\out\\render_0072.exr",
+              "NEG_DIGITS:\\out\\file_-01.exr",
+              "NEG_PRINTF:\\out\\file_-001.exr",
+              "NEG_HASH:\\out\\file_-001.exr",
+              "MULTI_EXT:\\out\\render.0072.exr",
+              "VFX_VERSION:\\out\\file.v2.072.exr",
+              "DOT_ONLY:\\out\\file_0072.001",
+              "MIXED_HP:\\out\\f_%d_abc_042.exr",
+              "MIXED_DP:\\out\\file_%04d_072.exr",
+          ]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'DIGITS:{{ digits }}')

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--with-number.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.2--with-number.test.yaml
@@ -26,79 +26,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = [
-              "STR:file_072.exr",
-              "DIGITS:/out/file_072.exr",
-              "PRINTF_BARE:/out/file_72.exr",
-              "PRINTF_PAD:/out/file_0072.exr",
-              "HASH4:/out/file_0072.exr",
-              "HASH6:/out/file_000072.exr",
-              "OVERFLOW:/out/file_10000.exr",
-              "NO_PATTERN:/out/render_0072.exr",
-              "NEG_DIGITS:/out/file_-01.exr",
-              "NEG_PRINTF:/out/file_-001.exr",
-              "NEG_HASH:/out/file_-001.exr",
-              "MULTI_EXT:/out/render.0072.exr",
-              "VFX_VERSION:/out/file.v2.072.exr",
-              "DOT_ONLY:/out/file_0072.001",
-              "MIXED_HP:/out/f_%d_abc_042.exr",
-              "MIXED_DP:/out/file_%04d_072.exr",
-          ]
-          EXPECTED_WINDOWS = [
-              "STR:file_072.exr",
-              "DIGITS:\\out\\file_072.exr",
-              "PRINTF_BARE:\\out\\file_72.exr",
-              "PRINTF_PAD:\\out\\file_0072.exr",
-              "HASH4:\\out\\file_0072.exr",
-              "HASH6:\\out\\file_000072.exr",
-              "OVERFLOW:\\out\\file_10000.exr",
-              "NO_PATTERN:\\out\\render_0072.exr",
-              "NEG_DIGITS:\\out\\file_-01.exr",
-              "NEG_PRINTF:\\out\\file_-001.exr",
-              "NEG_HASH:\\out\\file_-001.exr",
-              "MULTI_EXT:\\out\\render.0072.exr",
-              "VFX_VERSION:\\out\\file.v2.072.exr",
-              "DOT_ONLY:\\out\\file_0072.001",
-              "MIXED_HP:\\out\\f_%d_abc_042.exr",
-              "MIXED_DP:\\out\\file_%04d_072.exr",
-          ]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["STR:file_072.exr", "DIGITS:/out/file_072.exr", "PRINTF_BARE:/out/file_72.exr", "PRINTF_PAD:/out/file_0072.exr", "HASH4:/out/file_0072.exr", "HASH6:/out/file_000072.exr", "OVERFLOW:/out/file_10000.exr", "NO_PATTERN:/out/render_0072.exr", "NEG_DIGITS:/out/file_-01.exr", "NEG_PRINTF:/out/file_-001.exr", "NEG_HASH:/out/file_-001.exr", "MULTI_EXT:/out/render.0072.exr", "VFX_VERSION:/out/file.v2.072.exr", "DOT_ONLY:/out/file_0072.001", "MIXED_HP:/out/f_%d_abc_042.exr", "MIXED_DP:/out/file_%04d_072.exr"], "expected_windows": ["STR:file_072.exr", "DIGITS:\\out\\file_072.exr", "PRINTF_BARE:\\out\\file_72.exr", "PRINTF_PAD:\\out\\file_0072.exr", "HASH4:\\out\\file_0072.exr", "HASH6:\\out\\file_000072.exr", "OVERFLOW:\\out\\file_10000.exr", "NO_PATTERN:\\out\\render_0072.exr", "NEG_DIGITS:\\out\\file_-01.exr", "NEG_PRINTF:\\out\\file_-001.exr", "NEG_HASH:\\out\\file_-001.exr", "MULTI_EXT:\\out\\render.0072.exr", "VFX_VERSION:\\out\\file.v2.072.exr", "DOT_ONLY:\\out\\file_0072.001", "MIXED_HP:\\out\\f_%d_abc_042.exr", "MIXED_DP:\\out\\file_%04d_072.exr"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/EXPR/jobs/fail--in-conditional.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/fail--in-conditional.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["VAL:5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'VAL:{{ Param.X if Param.X > 0 else fail("must be positive") }}')
 expected:

--- a/conformance-tests/2023-09/EXPR/jobs/fail--in-conditional.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/fail--in-conditional.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["VAL:5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["VAL:5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'VAL:{{ Param.X if Param.X > 0 else fail("must be positive") }}')

--- a/conformance-tests/2023-09/EXPR/jobs/noreturn--conditional-type.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/noreturn--conditional-type.test.yaml
@@ -13,10 +13,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["INT:15", "BOOL:yes"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - >-
             print(r'INT:{{ (Param.X if Param.X > 0 else fail("bad")) + 10 }}')

--- a/conformance-tests/2023-09/EXPR/jobs/noreturn--conditional-type.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/noreturn--conditional-type.test.yaml
@@ -16,43 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["INT:15", "BOOL:yes"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["INT:15", "BOOL:yes"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - >-

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/5--notify-period-format-string.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/5--notify-period-format-string.test.yaml
@@ -15,43 +15,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["NOTIFY_OK"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["NOTIFY_OK"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - "print('NOTIFY_OK')"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/5--notify-period-format-string.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/5--notify-period-format-string.test.yaml
@@ -12,10 +12,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["NOTIFY_OK"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - "print('NOTIFY_OK')"
           cancelation:

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/5--timeout-format-string.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/5--timeout-format-string.test.yaml
@@ -11,11 +11,48 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["TIMEOUT_OK"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           timeout: "{{Param.TimeoutSeconds}}"
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - "print('TIMEOUT_OK')"
 expected:

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/5--timeout-format-string.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/5--timeout-format-string.test.yaml
@@ -14,44 +14,18 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["TIMEOUT_OK"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["TIMEOUT_OK"]}
       actions:
         onRun:
           timeout: "{{Param.TimeoutSeconds}}"
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - "print('TIMEOUT_OK')"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-auto-posix.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-auto-posix.test.yaml
@@ -9,6 +9,40 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["EOL:LF"]
+          FORBIDDEN = ["EOL:CRLF"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: script
         type: TEXT
         data: |
@@ -30,6 +64,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - "{{Task.File.checker}}"
           - "{{Task.File.script}}"
 expected:

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-auto-posix.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-auto-posix.test.yaml
@@ -11,38 +11,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["EOL:LF"]
-          FORBIDDEN = ["EOL:CRLF"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["EOL:LF"], "forbidden": ["EOL:CRLF"]}
       - name: script
         type: TEXT
         data: |
@@ -65,6 +38,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - "{{Task.File.checker}}"
           - "{{Task.File.script}}"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-auto-windows.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-auto-windows.test.yaml
@@ -11,38 +11,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["EOL:CRLF"]
-          FORBIDDEN = ["EOL:LF"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["EOL:CRLF"], "forbidden": ["EOL:LF"]}
       - name: script
         type: TEXT
         data: |
@@ -65,6 +38,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - "{{Task.File.checker}}"
           - "{{Task.File.script}}"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-auto-windows.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-auto-windows.test.yaml
@@ -9,6 +9,40 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["EOL:CRLF"]
+          FORBIDDEN = ["EOL:LF"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: script
         type: TEXT
         data: |
@@ -30,6 +64,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - "{{Task.File.checker}}"
           - "{{Task.File.script}}"
 expected:

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-crlf.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-crlf.test.yaml
@@ -9,38 +9,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["EOL:CRLF"]
-          FORBIDDEN = ["EOL:LF"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["EOL:CRLF"], "forbidden": ["EOL:LF"]}
       - name: script
         type: TEXT
         data: |
@@ -63,6 +36,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - "{{Task.File.checker}}"
           - "{{Task.File.script}}"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-crlf.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-crlf.test.yaml
@@ -7,6 +7,40 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["EOL:CRLF"]
+          FORBIDDEN = ["EOL:LF"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: script
         type: TEXT
         data: |
@@ -28,6 +62,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - "{{Task.File.checker}}"
           - "{{Task.File.script}}"
 expected:

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-lf.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-lf.test.yaml
@@ -9,38 +9,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["EOL:LF"]
-          FORBIDDEN = ["EOL:CRLF"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["EOL:LF"], "forbidden": ["EOL:CRLF"]}
       - name: script
         type: TEXT
         data: |
@@ -63,6 +36,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - "{{Task.File.checker}}"
           - "{{Task.File.script}}"

--- a/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-lf.test.yaml
+++ b/conformance-tests/2023-09/FEATURE_BUNDLE_1/jobs/6.1--end-of-line-lf.test.yaml
@@ -7,6 +7,40 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["EOL:LF"]
+          FORBIDDEN = ["EOL:CRLF"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: script
         type: TEXT
         data: |
@@ -28,6 +62,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - "{{Task.File.checker}}"
           - "{{Task.File.script}}"
 expected:

--- a/conformance-tests/2023-09/REDACTED_ENV_VARS/jobs/unset-takes-precedence.test.yaml
+++ b/conformance-tests/2023-09/REDACTED_ENV_VARS/jobs/unset-takes-precedence.test.yaml
@@ -19,43 +19,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MY_VAR:NOT_SET"]
-          FORBIDDEN = ["secret_data"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MY_VAR:NOT_SET"], "forbidden": ["secret_data"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - import os; print('MY_VAR:' + os.environ.get('MY_VAR', 'NOT_SET'))

--- a/conformance-tests/2023-09/REDACTED_ENV_VARS/jobs/unset-takes-precedence.test.yaml
+++ b/conformance-tests/2023-09/REDACTED_ENV_VARS/jobs/unset-takes-precedence.test.yaml
@@ -16,10 +16,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MY_VAR:NOT_SET"]
+          FORBIDDEN = ["secret_data"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - import os; print('MY_VAR:' + os.environ.get('MY_VAR', 'NOT_SET'))
 expected:

--- a/conformance-tests/2023-09/base/jobs/1.1--basic-job-creation.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--basic-job-creation.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:hello"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:hello"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:hello')

--- a/conformance-tests/2023-09/base/jobs/1.1--basic-job-creation.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--basic-job-creation.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:hello"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:hello')
 expected:

--- a/conformance-tests/2023-09/base/jobs/1.1--default-parameter-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--default-parameter-value.test.yaml
@@ -11,43 +11,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:default"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:default"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Version}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--default-parameter-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--default-parameter-value.test.yaml
@@ -8,10 +8,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:default"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Version}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/1.1--float-parameter-high-precision-decimal.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--float-parameter-high-precision-decimal.test.yaml
@@ -7,10 +7,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:3.141592653589793"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Scale}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--float-parameter-high-precision-decimal.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--float-parameter-high-precision-decimal.test.yaml
@@ -10,43 +10,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:3.141592653589793"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:3.141592653589793"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Scale}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--float-parameter-int-string-coercion-valid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--float-parameter-int-string-coercion-valid.test.yaml
@@ -10,43 +10,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Scale}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--float-parameter-int-string-coercion-valid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--float-parameter-int-string-coercion-valid.test.yaml
@@ -7,10 +7,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Scale}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--float-parameter-string-coercion-valid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--float-parameter-string-coercion-valid.test.yaml
@@ -7,10 +7,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:5.5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Scale}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--float-parameter-string-coercion-valid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--float-parameter-string-coercion-valid.test.yaml
@@ -10,43 +10,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:5.5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:5.5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Scale}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--float-parameter-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--float-parameter-substitution.test.yaml
@@ -10,43 +10,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:1.5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:1.5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Scale}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--float-parameter-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--float-parameter-substitution.test.yaml
@@ -7,10 +7,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:1.5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Scale}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--int-parameter-string-coercion-valid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--int-parameter-string-coercion-valid.test.yaml
@@ -7,10 +7,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Count}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--int-parameter-string-coercion-valid.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--int-parameter-string-coercion-valid.test.yaml
@@ -10,43 +10,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Count}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--int-parameter-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--int-parameter-substitution.test.yaml
@@ -10,43 +10,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:42"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:42"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Count}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--int-parameter-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--int-parameter-substitution.test.yaml
@@ -7,10 +7,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:42"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Count}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--job-name-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--job-name-substitution.test.yaml
@@ -7,10 +7,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:1.0"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Version}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--job-name-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--job-name-substitution.test.yaml
@@ -10,43 +10,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:1.0"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:1.0"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Version}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--multiple-parameter-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--multiple-parameter-substitution.test.yaml
@@ -11,10 +11,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:MyProject"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Project}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--multiple-parameter-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--multiple-parameter-substitution.test.yaml
@@ -14,43 +14,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:MyProject"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:MyProject"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Project}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--override-default-parameter.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--override-default-parameter.test.yaml
@@ -8,10 +8,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:override"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.Version}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.1--override-default-parameter.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--override-default-parameter.test.yaml
@@ -11,43 +11,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:override"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:override"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Version}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--validation-valid-optional-parameter-with-default.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--validation-valid-optional-parameter-with-default.test.yaml
@@ -8,10 +8,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["OUTPUT:default_value"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.OptionalParam}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/1.1--validation-valid-optional-parameter-with-default.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--validation-valid-optional-parameter-with-default.test.yaml
@@ -11,43 +11,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["OUTPUT:default_value"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["OUTPUT:default_value"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.OptionalParam}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--validation-valid-path-default-within-template-dir.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--validation-valid-path-default-within-template-dir.test.yaml
@@ -11,45 +11,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = ["OUTPUT:", "/output"]
-          EXPECTED_WINDOWS = ["OUTPUT:", "\\output"]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["OUTPUT:", "/output"], "expected_windows": ["OUTPUT:", "\\output"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.OutputDir}}')

--- a/conformance-tests/2023-09/base/jobs/1.1--validation-valid-path-default-within-template-dir.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1--validation-valid-path-default-within-template-dir.test.yaml
@@ -8,10 +8,49 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = ["OUTPUT:", "/output"]
+          EXPECTED_WINDOWS = ["OUTPUT:", "\\output"]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'OUTPUT:{{Param.OutputDir}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/1.1.1--substitution-verification.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1.1--substitution-verification.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["JOBNAME:Job-1.0-MyProject"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["JOBNAME:Job-1.0-MyProject"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'JOBNAME:Job-{{Param.Version}}-{{Param.Project}}')

--- a/conformance-tests/2023-09/base/jobs/1.1.1--substitution-verification.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.1.1--substitution-verification.test.yaml
@@ -9,10 +9,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["JOBNAME:Job-1.0-MyProject"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'JOBNAME:Job-{{Param.Version}}-{{Param.Project}}')
 parameters:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--allowedvalues-intersection-string.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--allowedvalues-intersection-string.test.yaml
@@ -16,43 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["Value=bbbbb"]
-          FORBIDDEN = ["Value=aaa"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["Value=bbbbb"], "forbidden": ["Value=aaa"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'Value={{Param.Value}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--allowedvalues-intersection-string.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--allowedvalues-intersection-string.test.yaml
@@ -13,10 +13,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["Value=bbbbb"]
+          FORBIDDEN = ["Value=aaa"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'Value={{Param.Value}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--allowedvalues-intersection.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--allowedvalues-intersection.test.yaml
@@ -13,10 +13,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["Foo=10"]
+          FORBIDDEN = ["Foo=20"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'Foo={{Param.Foo}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--allowedvalues-intersection.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--allowedvalues-intersection.test.yaml
@@ -16,43 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["Foo=10"]
-          FORBIDDEN = ["Foo=20"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["Foo=10"], "forbidden": ["Foo=20"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'Foo={{Param.Foo}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--compatible-string-params.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--compatible-string-params.test.yaml
@@ -8,10 +8,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MERGE:Config=job-default"]
+          FORBIDDEN = ["\u007b\u007bParam.", "env-default"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'MERGE:Config={{Param.Config}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--compatible-string-params.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--compatible-string-params.test.yaml
@@ -11,43 +11,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MERGE:Config=job-default"]
-          FORBIDDEN = ["\u007b\u007bParam.", "env-default"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MERGE:Config=job-default"], "forbidden": ["\u007b\u007bParam.", "env-default"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'MERGE:Config={{Param.Config}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-float-range.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-float-range.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["Scale=2.5"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["Scale=2.5"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'Scale={{Param.Scale}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-float-range.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-float-range.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["Scale=2.5"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'Scale={{Param.Scale}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-int-range.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-int-range.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["Count=50"]
+          FORBIDDEN = ["Count=0"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'Count={{Param.Count}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-int-range.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-int-range.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["Count=50"]
-          FORBIDDEN = ["Count=0"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["Count=50"], "forbidden": ["Count=0"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'Count={{Param.Count}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-maxlength.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-maxlength.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["Value=test-value"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["Value=test-value"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'Value={{Param.Value}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-maxlength.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-maxlength.test.yaml
@@ -9,10 +9,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["Value=test-value"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'Value={{Param.Value}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-minlength.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-minlength.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["Value=test-value"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["Value=test-value"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'Value={{Param.Value}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-minlength.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-minlength.test.yaml
@@ -9,10 +9,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["Value=test-value"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'Value={{Param.Value}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-string-length.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-string-length.test.yaml
@@ -13,43 +13,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["Name=test-value"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["Name=test-value"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'Name={{Param.Name}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-string-length.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--constraint-narrowing-string-length.test.yaml
@@ -10,10 +10,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["Name=test-value"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'Name={{Param.Name}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--default-from-env-when-job-has-none.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--default-from-env-when-job-has-none.test.yaml
@@ -14,43 +14,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MERGE:default=medium"]
-          FORBIDDEN = ["MERGE:default=low", "MERGE:default=high"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MERGE:default=medium"], "forbidden": ["MERGE:default=low", "MERGE:default=high"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'MERGE:default={{Param.Quality}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--default-from-env-when-job-has-none.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--default-from-env-when-job-has-none.test.yaml
@@ -11,10 +11,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MERGE:default=medium"]
+          FORBIDDEN = ["MERGE:default=low", "MERGE:default=high"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'MERGE:default={{Param.Quality}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--default-from-job-template.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--default-from-job-template.test.yaml
@@ -15,43 +15,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MERGE:default=high"]
-          FORBIDDEN = ["MERGE:default=low"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MERGE:default=high"], "forbidden": ["MERGE:default=low"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'MERGE:default={{Param.Quality}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--default-from-job-template.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--default-from-job-template.test.yaml
@@ -12,10 +12,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MERGE:default=high"]
+          FORBIDDEN = ["MERGE:default=low"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'MERGE:default={{Param.Quality}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--job-default-takes-precedence.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--job-default-takes-precedence.test.yaml
@@ -8,10 +8,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["Setting=job-value"]
+          FORBIDDEN = ["Setting=env-value"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'Setting={{Param.Setting}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--job-default-takes-precedence.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--job-default-takes-precedence.test.yaml
@@ -11,43 +11,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["Setting=job-value"]
-          FORBIDDEN = ["Setting=env-value"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["Setting=job-value"], "forbidden": ["Setting=env-value"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'Setting={{Param.Setting}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--multiple-env-templates.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--multiple-env-templates.test.yaml
@@ -18,43 +18,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MERGE:Foo=8,Bar=bbbbbbbbbbbbbbbbbbbbbbbbb"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MERGE:Foo=8,Bar=bbbbbbbbbbbbbbbbbbbbbbbbb"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'MERGE:Foo={{Param.Foo}},Bar={{Param.Bar}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--multiple-env-templates.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--multiple-env-templates.test.yaml
@@ -15,10 +15,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MERGE:Foo=8,Bar=bbbbbbbbbbbbbbbbbbbbbbbbb"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'MERGE:Foo={{Param.Foo}},Bar={{Param.Bar}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/1.2.1--two-env-templates-only.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--two-env-templates-only.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MERGE:Foo=5,Bar=hello-world"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MERGE:Foo=5,Bar=hello-world"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'MERGE:Foo={{Param.Foo}},Bar={{Param.Bar}}')

--- a/conformance-tests/2023-09/base/jobs/1.2.1--two-env-templates-only.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/1.2.1--two-env-templates-only.test.yaml
@@ -9,10 +9,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MERGE:Foo=5,Bar=hello-world"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'MERGE:Foo={{Param.Foo}},Bar={{Param.Bar}}')
 environments:

--- a/conformance-tests/2023-09/base/jobs/2.2--path-uri-without-expr.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/2.2--path-uri-without-expr.test.yaml
@@ -14,43 +14,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["IS_ABS:True", "HAS_SCHEME:False"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["IS_ABS:True", "HAS_SCHEME:False"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/base/jobs/2.2--path-uri-without-expr.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/2.2--path-uri-without-expr.test.yaml
@@ -11,10 +11,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["IS_ABS:True", "HAS_SCHEME:False"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             import os

--- a/conformance-tests/2023-09/base/jobs/3.4--empty.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4--empty.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["TASK:executed"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["TASK:executed"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'TASK:executed')

--- a/conformance-tests/2023-09/base/jobs/3.4--empty.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4--empty.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["TASK:executed"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'TASK:executed')
 expected:

--- a/conformance-tests/2023-09/base/jobs/3.4.1--adv-format-string-single-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--adv-format-string-single-value.test.yaml
@@ -16,43 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["VAL:5"]
-          FORBIDDEN = ["VAL:4", "VAL:6"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["VAL:5"], "forbidden": ["VAL:4", "VAL:6"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')

--- a/conformance-tests/2023-09/base/jobs/3.4.1--adv-format-string-single-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--adv-format-string-single-value.test.yaml
@@ -13,10 +13,47 @@ template:
         type: INT
         range: '{{Param.Frame}}'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["VAL:5"]
+          FORBIDDEN = ["VAL:4", "VAL:6"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/3.4.1--adv-large-step-exceeds-range.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--adv-large-step-exceeds-range.test.yaml
@@ -9,10 +9,47 @@ template:
         type: INT
         range: 1-5:10
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["VAL:1"]
+          FORBIDDEN = ["VAL:0", "VAL:2"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/3.4.1--adv-large-step-exceeds-range.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--adv-large-step-exceeds-range.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["VAL:1"]
-          FORBIDDEN = ["VAL:0", "VAL:2"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["VAL:1"], "forbidden": ["VAL:0", "VAL:2"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')

--- a/conformance-tests/2023-09/base/jobs/3.4.1--single-negative-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--single-negative-value.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["VAL:-10"]
-          FORBIDDEN = ["VAL:-11", "VAL:-9"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["VAL:-10"], "forbidden": ["VAL:-11", "VAL:-9"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')

--- a/conformance-tests/2023-09/base/jobs/3.4.1--single-negative-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--single-negative-value.test.yaml
@@ -9,10 +9,47 @@ template:
         type: INT
         range: '-10'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["VAL:-10"]
+          FORBIDDEN = ["VAL:-11", "VAL:-9"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/3.4.1--single-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--single-value.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["VAL:5"]
-          FORBIDDEN = ["VAL:4", "VAL:6"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["VAL:5"], "forbidden": ["VAL:4", "VAL:6"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')

--- a/conformance-tests/2023-09/base/jobs/3.4.1--single-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--single-value.test.yaml
@@ -9,10 +9,47 @@ template:
         type: INT
         range: '5'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["VAL:5"]
+          FORBIDDEN = ["VAL:4", "VAL:6"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/3.4.1--single-zero.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--single-zero.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["VAL:0"]
-          FORBIDDEN = ["VAL:-1", "VAL:1"]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["VAL:0"], "forbidden": ["VAL:-1", "VAL:1"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')

--- a/conformance-tests/2023-09/base/jobs/3.4.1--single-zero.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/3.4.1--single-zero.test.yaml
@@ -9,10 +9,47 @@ template:
         type: INT
         range: '0'
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["VAL:0"]
+          FORBIDDEN = ["VAL:-1", "VAL:1"]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'VAL:{{Task.Param.Val}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/4--openjd-env-sets-variable.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/4--openjd-env-sets-variable.test.yaml
@@ -13,10 +13,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["MY_VAR_IS:myvalue"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - import os; print('MY_VAR_IS:' + os.environ.get('MY_VAR', ''))
 expected:

--- a/conformance-tests/2023-09/base/jobs/4--openjd-env-sets-variable.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/4--openjd-env-sets-variable.test.yaml
@@ -16,43 +16,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["MY_VAR_IS:myvalue"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["MY_VAR_IS:myvalue"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - import os; print('MY_VAR_IS:' + os.environ.get('MY_VAR', ''))

--- a/conformance-tests/2023-09/base/jobs/4--openjd-unset-env.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/4--openjd-unset-env.test.yaml
@@ -18,43 +18,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["UNSET_ME_IS:UNSET"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["UNSET_ME_IS:UNSET"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - import os; print('UNSET_ME_IS:' + os.environ.get('UNSET_ME', 'UNSET'))

--- a/conformance-tests/2023-09/base/jobs/4--openjd-unset-env.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/4--openjd-unset-env.test.yaml
@@ -15,10 +15,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["UNSET_ME_IS:UNSET"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - import os; print('UNSET_ME_IS:' + os.environ.get('UNSET_ME', 'UNSET'))
 expected:

--- a/conformance-tests/2023-09/base/jobs/6--embedded-file-in-session-dir.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/6--embedded-file-in-session-dir.test.yaml
@@ -7,38 +7,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["FILE_IN_SESSION_DIR:true"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["FILE_IN_SESSION_DIR:true"]}
       - name: testfile
         type: TEXT
         data: test content
@@ -47,6 +20,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - import os; path = r'{{Task.File.testfile}}'; session_dir = r'{{Session.WorkingDirectory}}';

--- a/conformance-tests/2023-09/base/jobs/6--embedded-file-in-session-dir.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/6--embedded-file-in-session-dir.test.yaml
@@ -5,6 +5,40 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["FILE_IN_SESSION_DIR:true"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: testfile
         type: TEXT
         data: test content
@@ -12,6 +46,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - import os; path = r'{{Task.File.testfile}}'; session_dir = r'{{Session.WorkingDirectory}}';
             print('FILE_IN_SESSION_DIR:true' if os.path.dirname(path).startswith(session_dir)

--- a/conformance-tests/2023-09/base/jobs/6--embedded-file-runnable-permissions.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/6--embedded-file-runnable-permissions.test.yaml
@@ -5,6 +5,42 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = ["EXECUTABLE:True"]
+          EXPECTED_WINDOWS = []
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: runnable_script
         type: TEXT
         runnable: true
@@ -15,6 +51,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - import os, stat; path = r'{{Task.File.runnable_script}}'; mode = os.stat(path).st_mode;
             is_exec = bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)); print(f'EXECUTABLE:{is_exec}')

--- a/conformance-tests/2023-09/base/jobs/6--embedded-file-runnable-permissions.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/6--embedded-file-runnable-permissions.test.yaml
@@ -7,40 +7,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = ["EXECUTABLE:True"]
-          EXPECTED_WINDOWS = []
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["EXECUTABLE:True"], "expected_windows": []}
       - name: runnable_script
         type: TEXT
         runnable: true
@@ -52,6 +23,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - import os, stat; path = r'{{Task.File.runnable_script}}'; mode = os.stat(path).st_mode;

--- a/conformance-tests/2023-09/base/jobs/6--session-var-in-embedded-data.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/6--session-var-in-embedded-data.test.yaml
@@ -5,6 +5,42 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = ["SESSION_DIR:/"]
+          EXPECTED_WINDOWS = ["SESSION_DIR:", ":\\"]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: script
         type: TEXT
         data: 'import sys
@@ -16,6 +52,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - '{{Task.File.script}}'
 expected:
   output_posix:

--- a/conformance-tests/2023-09/base/jobs/6--session-var-in-embedded-data.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/6--session-var-in-embedded-data.test.yaml
@@ -7,40 +7,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = ["SESSION_DIR:/"]
-          EXPECTED_WINDOWS = ["SESSION_DIR:", ":\\"]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["SESSION_DIR:/"], "expected_windows": ["SESSION_DIR:", ":\\"]}
       - name: script
         type: TEXT
         data: 'import sys
@@ -53,6 +24,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - '{{Task.File.script}}'
 expected:

--- a/conformance-tests/2023-09/base/jobs/7.3--adjacent-substitutions.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--adjacent-substitutions.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:HelloWorld"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:HelloWorld"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:{{Param.A}}{{Param.B}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--adjacent-substitutions.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--adjacent-substitutions.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:HelloWorld"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:{{Param.A}}{{Param.B}}')
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--empty-value-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--empty-value-substitution.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:Value: []"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - 'print(''RESULT:Value: [{{Param.Empty}}]'')'
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--empty-value-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--empty-value-substitution.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:Value: []"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:Value: []"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - 'print(''RESULT:Value: [{{Param.Empty}}]'')'

--- a/conformance-tests/2023-09/base/jobs/7.3--float-and-string-mixed.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--float-and-string-mixed.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:4.098-hello1"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:4.098-hello1"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:{{Param.Float}}-{{Param.String}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--float-and-string-mixed.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--float-and-string-mixed.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:4.098-hello1"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:{{Param.Float}}-{{Param.String}}')
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--float-formatting-precision.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--float-formatting-precision.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:Value: 4.098"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:Value: 4.098"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - 'print(''RESULT:Value: {{Param.Float}}'')'

--- a/conformance-tests/2023-09/base/jobs/7.3--float-formatting-precision.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--float-formatting-precision.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:Value: 4.098"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - 'print(''RESULT:Value: {{Param.Float}}'')'
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--multiple-substitutions.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--multiple-substitutions.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:One and Two"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:One and Two"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:{{Param.First}} and {{Param.Second}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--multiple-substitutions.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--multiple-substitutions.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:One and Two"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:{{Param.First}} and {{Param.Second}}')
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--numeric-value-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--numeric-value-substitution.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:Count: 100"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:Count: 100"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - 'print(''RESULT:Count: {{Param.Count}}'')'

--- a/conformance-tests/2023-09/base/jobs/7.3--numeric-value-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--numeric-value-substitution.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:Count: 100"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - 'print(''RESULT:Count: {{Param.Count}}'')'
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--param-in-capability.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--param-in-capability.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:high"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:{{Param.Quality}}')
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--param-in-capability.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--param-in-capability.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:high"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:high"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:{{Param.Quality}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--path-param-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--path-param-mapping-posix.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:/mapped/path"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:/mapped/path"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:{{Param.InputPath}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--path-param-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--path-param-mapping-posix.test.yaml
@@ -9,10 +9,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:/mapped/path"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:{{Param.InputPath}}')
 

--- a/conformance-tests/2023-09/base/jobs/7.3--path-param-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--path-param-mapping-windows.test.yaml
@@ -22,10 +22,53 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = [
+              "DRIVE_BS:E:\\mapped\\path",
+              "DRIVE_FS:E:\\mapped\\path",
+              "DRIVE_MIXED:E:\\mapped\\path\\somewhere",
+              "UNC_BS:Z:\\share\\path",
+              "UNC_FS:Z:\\share\\path",
+          ]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - |
             print(r'DRIVE_BS:{{Param.DriveBs}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--path-param-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--path-param-mapping-windows.test.yaml
@@ -25,49 +25,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = [
-              "DRIVE_BS:E:\\mapped\\path",
-              "DRIVE_FS:E:\\mapped\\path",
-              "DRIVE_MIXED:E:\\mapped\\path\\somewhere",
-              "UNC_BS:Z:\\share\\path",
-              "UNC_FS:Z:\\share\\path",
-          ]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["DRIVE_BS:E:\\mapped\\path", "DRIVE_FS:E:\\mapped\\path", "DRIVE_MIXED:E:\\mapped\\path\\somewhere", "UNC_BS:Z:\\share\\path", "UNC_FS:Z:\\share\\path"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - |

--- a/conformance-tests/2023-09/base/jobs/7.3--plain-string.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--plain-string.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:Hello World"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:Hello World"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:Hello World')

--- a/conformance-tests/2023-09/base/jobs/7.3--plain-string.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--plain-string.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:Hello World"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:Hello World')
 expected:

--- a/conformance-tests/2023-09/base/jobs/7.3--rawparam-no-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--rawparam-no-mapping-posix.test.yaml
@@ -12,43 +12,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RAW:/original/path", "MAPPED:/mapped/path"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RAW:/original/path", "MAPPED:/mapped/path"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RAW:{{RawParam.InputPath}}');print(r'MAPPED:{{Param.InputPath}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--rawparam-no-mapping-posix.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--rawparam-no-mapping-posix.test.yaml
@@ -9,10 +9,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RAW:/original/path", "MAPPED:/mapped/path"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RAW:{{RawParam.InputPath}}');print(r'MAPPED:{{Param.InputPath}}')
 

--- a/conformance-tests/2023-09/base/jobs/7.3--rawparam-no-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--rawparam-no-mapping-windows.test.yaml
@@ -12,10 +12,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RAW:D:\\original\\path", "MAPPED:E:\\mapped\\path"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RAW:{{RawParam.InputPath}}');print(r'MAPPED:{{Param.InputPath}}')
 

--- a/conformance-tests/2023-09/base/jobs/7.3--rawparam-no-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--rawparam-no-mapping-windows.test.yaml
@@ -15,43 +15,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RAW:D:\\original\\path", "MAPPED:E:\\mapped\\path"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RAW:D:\\original\\path", "MAPPED:E:\\mapped\\path"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RAW:{{RawParam.InputPath}}');print(r'MAPPED:{{Param.InputPath}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--rawparam-string.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--rawparam-string.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:TestValue"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:{{RawParam.Name}}')
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--rawparam-string.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--rawparam-string.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:TestValue"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:TestValue"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:{{RawParam.Name}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--session-has-path-mapping.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--session-has-path-mapping.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["HAS_MAPPING:false"]
+          FORBIDDEN = ["\u007b\u007bSession."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'HAS_MAPPING:{{Session.HasPathMappingRules}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/7.3--session-has-path-mapping.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--session-has-path-mapping.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["HAS_MAPPING:false"]
-          FORBIDDEN = ["\u007b\u007bSession."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["HAS_MAPPING:false"], "forbidden": ["\u007b\u007bSession."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'HAS_MAPPING:{{Session.HasPathMappingRules}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--session-path-mapping-rules-file.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--session-path-mapping-rules-file.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:true"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:true')
           - FILE:{{Session.PathMappingRulesFile}}

--- a/conformance-tests/2023-09/base/jobs/7.3--session-path-mapping-rules-file.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--session-path-mapping-rules-file.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:true"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:true"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:true')

--- a/conformance-tests/2023-09/base/jobs/7.3--session-working-dir-env-var.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--session-working-dir-env-var.test.yaml
@@ -9,43 +9,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["ENV_SET:True", "VALUES_MATCH:True"]
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["ENV_SET:True", "VALUES_MATCH:True"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - "import os; env_val = os.environ.get('OPENJD_SESSION_WORKING_DIR', 'MISSING'); template_val = r'{{Session.WorkingDirectory}}'; print(f'ENV_SET:{env_val != \"MISSING\"}'); print(f'VALUES_MATCH:{env_val == template_val}')"

--- a/conformance-tests/2023-09/base/jobs/7.3--session-working-dir-env-var.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--session-working-dir-env-var.test.yaml
@@ -6,10 +6,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["ENV_SET:True", "VALUES_MATCH:True"]
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - "import os; env_val = os.environ.get('OPENJD_SESSION_WORKING_DIR', 'MISSING'); template_val = r'{{Session.WorkingDirectory}}'; print(f'ENV_SET:{env_val != \"MISSING\"}'); print(f'VALUES_MATCH:{env_val == template_val}')"
 expected:

--- a/conformance-tests/2023-09/base/jobs/7.3--session-working-directory.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--session-working-directory.test.yaml
@@ -4,10 +4,49 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = ["SESSION_DIR:/"]
+          EXPECTED_WINDOWS = ["SESSION_DIR:", ":\\"]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'SESSION_DIR:{{Session.WorkingDirectory}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/7.3--session-working-directory.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--session-working-directory.test.yaml
@@ -7,45 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = ["SESSION_DIR:/"]
-          EXPECTED_WINDOWS = ["SESSION_DIR:", ":\\"]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["SESSION_DIR:/"], "expected_windows": ["SESSION_DIR:", ":\\"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'SESSION_DIR:{{Session.WorkingDirectory}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--simple-param-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--simple-param-substitution.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:Hello World!"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:Hello {{Param.Name}}!')
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--simple-param-substitution.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--simple-param-substitution.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:Hello World!"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:Hello World!"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:Hello {{Param.Name}}!')

--- a/conformance-tests/2023-09/base/jobs/7.3--single-brace-literal.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--single-brace-literal.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:Hello \u007bParam.Name\u007d"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:Hello \u007bParam.Name\u007d"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'RESULT:Hello {Param.Name}')

--- a/conformance-tests/2023-09/base/jobs/7.3--single-brace-literal.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--single-brace-literal.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:Hello \u007bParam.Name\u007d"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'RESULT:Hello {Param.Name}')
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--special-characters-in-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--special-characters-in-value.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT:Path: /path/with spaces/and$pecial"]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - 'print(''RESULT:Path: {{Param.Path}}'')'
   parameterDefinitions:

--- a/conformance-tests/2023-09/base/jobs/7.3--special-characters-in-value.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--special-characters-in-value.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT:Path: /path/with spaces/and$pecial"]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT:Path: /path/with spaces/and$pecial"], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - 'print(''RESULT:Path: {{Param.Path}}'')'

--- a/conformance-tests/2023-09/base/jobs/7.3--task-file-reference.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--task-file-reference.test.yaml
@@ -5,6 +5,42 @@ template:
   - name: Step1
     script:
       embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED_POSIX = ["SCRIPT_PATH:/"]
+          EXPECTED_WINDOWS = ["SCRIPT_PATH:", ":\\"]
+          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
+          FORBIDDEN = []
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       - name: myscript
         type: TEXT
         data: echo hello
@@ -12,6 +48,8 @@ template:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - print(r'SCRIPT_PATH:{{Task.File.myscript}}')
 expected:

--- a/conformance-tests/2023-09/base/jobs/7.3--task-file-reference.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--task-file-reference.test.yaml
@@ -7,40 +7,11 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED_POSIX = ["SCRIPT_PATH:/"]
-          EXPECTED_WINDOWS = ["SCRIPT_PATH:", ":\\"]
-          EXPECTED = EXPECTED_WINDOWS if sys.platform == "win32" else EXPECTED_POSIX
-          FORBIDDEN = []
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected_posix": ["SCRIPT_PATH:/"], "expected_windows": ["SCRIPT_PATH:", ":\\"]}
       - name: myscript
         type: TEXT
         data: echo hello
@@ -49,6 +20,7 @@ template:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'SCRIPT_PATH:{{Task.File.myscript}}')

--- a/conformance-tests/2023-09/base/jobs/7.3--whitespace-in-braces.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--whitespace-in-braces.test.yaml
@@ -7,43 +7,17 @@ template:
       embeddedFiles:
       - name: OpenJDConformanceAssert
         type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
         data: |
-          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
-          # command, expanded by the implementation -- echoes its output so a runner that
-          # scans logs still sees the same lines, then checks that output against the
-          # literals below and exits non-zero on mismatch, so task exit status alone carries
-          # the verdict. The literals are literals, and diagnostics report a line's position
-          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
-          # says why both matter.
-          import subprocess
-          import sys
-
-          EXPECTED = ["RESULT: 4.098 - 10  "]
-          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
-          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
-          sys.stdout.write(completed.stdout)
-          sys.stderr.write(completed.stderr)
-          output = completed.stdout + completed.stderr
-
-          problems = []
-          if completed.returncode != 0:
-              problems.append("command exited with code %d" % completed.returncode)
-          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
-                       for i, line in enumerate(EXPECTED, 1) if line not in output]
-          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
-                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
-
-          for problem in problems:
-              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
-          if problems:
-              sys.exit(1)
-          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
-                           % (len(EXPECTED), len(FORBIDDEN)))
+          {"expected": ["RESULT: 4.098 - 10  "], "forbidden": ["\u007b\u007bParam.", "\u007b\u007bTask."]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - 'print(''RESULT: {{ Param.Float }} - {{    Param.End}}  '')'

--- a/conformance-tests/2023-09/base/jobs/7.3--whitespace-in-braces.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.3--whitespace-in-braces.test.yaml
@@ -4,10 +4,47 @@ template:
   steps:
   - name: Step1
     script:
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        data: |
+          # Self-asserting conformance wrapper. Runs `sys.argv[1:]` -- this case's original
+          # command, expanded by the implementation -- echoes its output so a runner that
+          # scans logs still sees the same lines, then checks that output against the
+          # literals below and exits non-zero on mismatch, so task exit status alone carries
+          # the verdict. The literals are literals, and diagnostics report a line's position
+          # rather than its text; conformance-tests/README.md, "Self-asserting job tests",
+          # says why both matter.
+          import subprocess
+          import sys
+
+          EXPECTED = ["RESULT: 4.098 - 10  "]
+          FORBIDDEN = ["\u007b\u007bParam.", "\u007b\u007bTask."]
+          completed = subprocess.run(sys.argv[1:], capture_output=True, text=True)
+          sys.stdout.write(completed.stdout)
+          sys.stderr.write(completed.stderr)
+          output = completed.stdout + completed.stderr
+
+          problems = []
+          if completed.returncode != 0:
+              problems.append("command exited with code %d" % completed.returncode)
+          problems += ["expected output line %d of %d not found" % (i, len(EXPECTED))
+                       for i, line in enumerate(EXPECTED, 1) if line not in output]
+          problems += ["forbidden output line %d of %d was present" % (i, len(FORBIDDEN))
+                       for i, line in enumerate(FORBIDDEN, 1) if line in output]
+
+          for problem in problems:
+              sys.stderr.write("OPENJD_CONFORMANCE_ASSERT_FAILED: %s\n" % problem)
+          if problems:
+              sys.exit(1)
+          sys.stdout.write("OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n"
+                           % (len(EXPECTED), len(FORBIDDEN)))
       actions:
         onRun:
           command: python
           args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
           - -c
           - 'print(''RESULT: {{ Param.Float }} - {{    Param.End}}  '')'
   parameterDefinitions:

--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -170,23 +170,46 @@ The `runOn` field restricts a test to run only on the listed operating systems. 
 ### Self-asserting job tests
 
 Many single-task job tests assert their own output, in addition to declaring it in
-`expected`. Their `onRun` takes one leading argument — an `OpenJDConformanceAssert`
-embedded file — followed by the case's original command and args:
+`expected`. Such a case carries two embedded files and prepends both to its `onRun`,
+ahead of the command and args it had before instrumentation:
 
 ```yaml
+      embeddedFiles:
+      - name: OpenJDConformanceAssert
+        type: TEXT
+        dataFile: _conformance_assert.py
+      - name: OpenJDConformanceExpect
+        type: TEXT
+        data: |
+          {"expected": ["OUTPUT:1.0"]}
       actions:
         onRun:
           command: python
           args:
           - '{{Task.File.OpenJDConformanceAssert}}'
+          - '{{Task.File.OpenJDConformanceExpect}}'
           - python
           - -c
           - print(r'OUTPUT:{{Param.Version}}')
 ```
 
-The wrapper runs `sys.argv[1:]`, echoes its output verbatim, compares that output
-against literals baked into the wrapper, and exits non-zero on mismatch. The task's
-exit status then carries the verdict.
+`_conformance_assert.py` is the wrapper, one flat file shared by every instrumented
+case. It runs `sys.argv[2:]`, echoes that output verbatim, compares it against the
+lines named in `argv[1]`, and exits non-zero on mismatch. The task's exit status then
+carries the verdict.
+
+**`dataFile` is a harness convention, not part of the job template schema.** It names
+a file relative to the conformance-tests root whose contents become the embedded
+file's `data`, and a harness must resolve it before submitting the template —
+`inline_data_files()` in `run_openjd_cli_tests.py` is ten lines and is the whole of
+it. Resolving it is the only preprocessing these tests require. Because `data` is
+required on an embedded file, a harness that skips the step submits an invalid
+template and fails loudly rather than silently dropping the assertion.
+
+The expect file is JSON, and mirrors the case's own `expected` block: `expected` and
+`forbidden` for lines that hold everywhere, `expected_posix` / `expected_windows`
+(and the `forbidden_` equivalents) when the two platforms differ. The wrapper reads
+the common list plus the one for the platform it is running on.
 
 This exists so that an implementation which can only observe **task status** — a
 service, rather than a CLI whose stdout the runner can read — still verifies output
@@ -200,19 +223,23 @@ Four properties matter if you write or edit one of these:
   implementation still expands the args list, so a case whose subject *is* that
   expansion stays under test — `expr1.3.2--list-flattens-in-args` asserts
   `ARG0:--width` … `COUNT:10`, which only holds if the list flattening still happens
-  where it always did.
-- **The literals are literals.** `expected.output` holds the already-substituted
-  value (`OUTPUT:1.0`, not `OUTPUT:{{Param.Version}}`). Injecting them by parameter
+  where it always did. This is also why the wrapper is generic and the case-specific
+  data lives beside it: nothing case-specific may displace the case's own argv.
+- **The literals are literals.** The expect file holds the already-substituted value
+  (`OUTPUT:1.0`, not `OUTPUT:{{Param.Version}}`). Injecting them by parameter
   reference would make the comparison self-referential: a substitution bug would
   corrupt both sides identically and the case would pass.
 - **Diagnostics report a line's position, never its text.**
-  `OPENJD_CONFORMANCE_ASSERT_FAILED: expected output line 1 of 2 not found`. Printing
-  the literal would place it in the very output a log-scanning runner searches, so a
-  failing case would satisfy that runner with its own error message. Read the position
-  against the case's `expected` block.
+  `OPENJD_CONFORMANCE_ASSERT_FAILED: exit=0 missing=[1] of 2 forbidden=[] of 0`.
+  Printing the literal would place it in the very output a log-scanning runner
+  searches, so a failing case would satisfy that runner with its own error message.
+  Read the positions against the case's `expected` block.
 - **Braces in a literal are written `\u007b` / `\u007d`.** Embedded file data is itself
-  a format string, and several cases forbid a literal `{{Param.` in their output.
-  Written raw, that literal would be parsed as a substitution.
+  a format string and there is no escape for `{{` in a 2023-09 template — a bare
+  `{{Param.` is a validation error, and `\{\{` and a doubled `{{{{` are not escapes
+  either. Several cases forbid a literal `{{Param.` in their output; JSON's own
+  `\uXXXX` escape decodes the braces back after the format-string pass has run, which
+  is why the expect file is JSON rather than plain argv text.
 
 On success the wrapper prints `OPENJD_CONFORMANCE_ASSERT_OK: <n> expected, <m>
 forbidden`. That line is how you confirm the assertion actually ran, rather than the
@@ -245,6 +272,10 @@ To validate your OpenJD library against these tests:
 2. For `*.yaml` files (without `.invalid`): verify your library accepts them
 3. For `*.invalid.yaml` files: verify your library rejects them
 4. For job execution tests (`.test.yaml`): extract template/parameters/environments, run the job, verify outputs match `expected` assertions, and require a clean exit unless the test declares `expected.taskFailure`
+5. Resolve `dataFile` on any embedded file into that file's contents as `data` before
+   submitting the template — see "Self-asserting job tests". This is the only
+   preprocessing the tests require, and skipping it makes the affected templates
+   invalid rather than silently weaker.
 
 ### Example Test Runner for openjd CLI
 

--- a/conformance-tests/README.md
+++ b/conformance-tests/README.md
@@ -160,7 +160,82 @@ The `taskFailure` assertion is for non-`.invalid.` job tests that succeed at the
 
 Use `taskFailure` instead of the `.invalid.test.yaml` suffix when you also want to assert specific `output`/`forbidden` lines on a failing run, or when you need to pin the propagated exit code.
 
+A valid job test with no `taskFailure` MUST exit `0`. Without that requirement the verdict
+rests entirely on substring matching, and a case whose task failed still passes as long as
+the expected lines turn up anywhere in the output — including inside the failure's own
+diagnostics.
+
 The `runOn` field restricts a test to run only on the listed operating systems. If omitted, the test runs on all platforms. Use this when a test requires a platform-specific command (e.g., `cmd` or `powershell` on Windows, `bash` on POSIX).
+
+### Self-asserting job tests
+
+Many single-task job tests assert their own output, in addition to declaring it in
+`expected`. Their `onRun` takes one leading argument — an `OpenJDConformanceAssert`
+embedded file — followed by the case's original command and args:
+
+```yaml
+      actions:
+        onRun:
+          command: python
+          args:
+          - '{{Task.File.OpenJDConformanceAssert}}'
+          - python
+          - -c
+          - print(r'OUTPUT:{{Param.Version}}')
+```
+
+The wrapper runs `sys.argv[1:]`, echoes its output verbatim, compares that output
+against literals baked into the wrapper, and exits non-zero on mismatch. The task's
+exit status then carries the verdict.
+
+This exists so that an implementation which can only observe **task status** — a
+service, rather than a CLI whose stdout the runner can read — still verifies output
+*content* rather than only that the task ran and exited `0`. `expected.output` and
+`expected.forbidden` are unchanged, so a runner that scans logs is unaffected; both
+mechanisms check the same thing by different means.
+
+Four properties matter if you write or edit one of these:
+
+- **The original argv is passed through, not embedded in the wrapper.** The
+  implementation still expands the args list, so a case whose subject *is* that
+  expansion stays under test — `expr1.3.2--list-flattens-in-args` asserts
+  `ARG0:--width` … `COUNT:10`, which only holds if the list flattening still happens
+  where it always did.
+- **The literals are literals.** `expected.output` holds the already-substituted
+  value (`OUTPUT:1.0`, not `OUTPUT:{{Param.Version}}`). Injecting them by parameter
+  reference would make the comparison self-referential: a substitution bug would
+  corrupt both sides identically and the case would pass.
+- **Diagnostics report a line's position, never its text.**
+  `OPENJD_CONFORMANCE_ASSERT_FAILED: expected output line 1 of 2 not found`. Printing
+  the literal would place it in the very output a log-scanning runner searches, so a
+  failing case would satisfy that runner with its own error message. Read the position
+  against the case's `expected` block.
+- **Braces in a literal are written `\u007b` / `\u007d`.** Embedded file data is itself
+  a format string, and several cases forbid a literal `{{Param.` in their output.
+  Written raw, that literal would be parsed as a substitution.
+
+On success the wrapper prints `OPENJD_CONFORMANCE_ASSERT_OK: <n> expected, <m>
+forbidden`. That line is how you confirm the assertion actually ran, rather than the
+case having passed for some other reason — worth checking, since the wrapper is only
+reached if the implementation actually executes the task's action.
+
+Four kinds of case deliberately stay status-only, because a task cannot assert them:
+
+- **Multi-task cases.** Each task sees only its own output, so a per-task exit code
+  cannot assert that N lines appeared across N tasks. These need aggregation outside
+  the job.
+- **Cases asserting the implementation's log handling.** `4--openjd-redacted-env`
+  expects `SECRET_IS:********`, which is the implementation's *redaction* of what the
+  task printed. The task sees the real value, so nothing it can observe about its own
+  output distinguishes redacted from leaked. Most of `REDACTED_ENV_VARS` is the same.
+- **Cases whose expected output comes from elsewhere.** `7.3--env-file-reference`
+  asserts a line printed by a job environment's `onEnter`; its task prints something
+  else entirely. `WRAP_ACTIONS` is excluded wholesale for the same reason plus a
+  stronger one: `onWrapTaskRun` *replaces* the task action, so a wrapper on the inner
+  action is usually never executed.
+- **Cases whose subject is the args list itself.** `wrap-no-args` asserts that
+  `WrappedAction.Args` surfaces as an empty list when the wrapped action has no args.
+  Adding an argument changes the subject.
 
 ## Writing Your Own Test Runner
 
@@ -169,7 +244,7 @@ To validate your OpenJD library against these tests:
 1. Parse the test files and naming conventions
 2. For `*.yaml` files (without `.invalid`): verify your library accepts them
 3. For `*.invalid.yaml` files: verify your library rejects them
-4. For job execution tests (`.test.yaml`): extract template/parameters/environments, run the job, verify outputs match `expected` assertions
+4. For job execution tests (`.test.yaml`): extract template/parameters/environments, run the job, verify outputs match `expected` assertions, and require a clean exit unless the test declares `expected.taskFailure`
 
 ### Example Test Runner for openjd CLI
 

--- a/conformance-tests/_conformance_assert.py
+++ b/conformance-tests/_conformance_assert.py
@@ -1,0 +1,60 @@
+# Self-asserting conformance wrapper, shared by every instrumented job test.
+#
+# A fixture pulls this file in with `dataFile: _conformance_assert.py` on an
+# embedded file named OpenJDConformanceAssert; the harness inlines it into that
+# file's `data` before submitting the template. See conformance-tests/README.md,
+# "Self-asserting job tests", for why this exists and what to preserve when
+# editing a case.
+#
+# Invoked as:
+#
+#   python <this file> <expect.json> <the case's original command and args...>
+#
+# argv[1] is the case's OpenJDConformanceExpect embedded file, holding the lines
+# the case must and must not print. argv[2:] is the case's original command,
+# already expanded by the implementation -- passed through rather than embedded
+# here, so a case whose subject IS that expansion stays under test.
+import json
+import subprocess
+import sys
+
+PLATFORM = "windows" if sys.platform == "win32" else "posix"
+
+
+def _lines(case, key):
+    """The case's `key` lines: the common ones plus this platform's.
+
+    Mirrors the fixture's own `expected` block, which spells a platform split
+    as `output` plus `output_posix` / `output_windows`.
+    """
+    return list(case.get(key) or []) + list(case.get("%s_%s" % (key, PLATFORM)) or [])
+
+
+with open(sys.argv[1]) as handle:
+    case = json.load(handle)
+expected = _lines(case, "expected")
+forbidden = _lines(case, "forbidden")
+
+completed = subprocess.run(sys.argv[2:], capture_output=True, text=True)
+# Echoed verbatim so a runner that scans logs still sees the same lines.
+sys.stdout.write(completed.stdout)
+sys.stderr.write(completed.stderr)
+output = completed.stdout + completed.stderr
+
+missing = [i for i, line in enumerate(expected, 1) if line not in output]
+present = [i for i, line in enumerate(forbidden, 1) if line in output]
+if completed.returncode or missing or present:
+    # Positions, never the text. Printing a literal would place it in the very
+    # output a log-scanning runner searches, so a failing case would satisfy
+    # that runner with its own error message. Read the positions against the
+    # case's `expected` block.
+    sys.stderr.write(
+        "OPENJD_CONFORMANCE_ASSERT_FAILED: exit=%s missing=%s of %d forbidden=%s of %d\n"
+        % (completed.returncode, missing, len(expected), present, len(forbidden))
+    )
+    sys.exit(1)
+# How you confirm the assertion actually ran, rather than the case having passed
+# for some other reason.
+sys.stdout.write(
+    "OPENJD_CONFORMANCE_ASSERT_OK: %d expected, %d forbidden\n" % (len(expected), len(forbidden))
+)

--- a/conformance-tests/run_openjd_cli_tests.py
+++ b/conformance-tests/run_openjd_cli_tests.py
@@ -84,11 +84,41 @@ def should_skip_test(test: dict) -> bool:
     return OPERATING_SYSTEM not in run_on
 
 
+def inline_data_files(node) -> None:
+    """Resolve `dataFile:` on embedded files into the `data:` the spec requires.
+
+    A harness convention, not part of the job template schema: `dataFile` names
+    a file relative to the conformance-tests root whose contents become the
+    embedded file's `data`. It exists so the self-asserting wrapper can live in
+    one flat file (`_conformance_assert.py`) instead of being copied into every
+    instrumented fixture. See README.md, "Self-asserting job tests".
+
+    Resolving it is the only preprocessing a harness has to do; everything a
+    case asserts stays in the case. `data` is required on an embedded file, so a
+    harness that skips this step submits an invalid template and fails loudly
+    rather than silently dropping the assertion.
+    """
+    if isinstance(node, dict):
+        for embedded_file in node.get("embeddedFiles") or []:
+            if isinstance(embedded_file, dict) and "dataFile" in embedded_file:
+                relative = embedded_file.pop("dataFile")
+                embedded_file["data"] = (CONFORMANCE_DIR / relative).read_text()
+        for value in node.values():
+            inline_data_files(value)
+    elif isinstance(node, list):
+        for value in node:
+            inline_data_files(value)
+
+
 def run_job(test_path: Path) -> tuple[bool, str] | None:
     test = load_yaml_or_json(test_path)
 
     if should_skip_test(test):
         return None
+
+    inline_data_files(test.get("template"))
+    for environment in test.get("environments", []):
+        inline_data_files(environment)
 
     expect_failure = ".invalid." in test_path.name
 

--- a/conformance-tests/run_openjd_cli_tests.py
+++ b/conformance-tests/run_openjd_cli_tests.py
@@ -139,7 +139,20 @@ def run_job(test_path: Path) -> tuple[bool, str] | None:
         # propagation is verified for a non-.invalid. test that must still make
         # assertions about its output.
         task_failure = expected.get("taskFailure")
-        if task_failure is not None:
+        if task_failure is None:
+            # A valid test with no declared task failure must run clean. Without
+            # this the verdict rests entirely on substring matching, and a case
+            # whose task failed still passes as long as the expected lines appear
+            # somewhere in the output -- including inside the failure's own
+            # diagnostics. Self-asserting cases depend on this check: they carry
+            # their verdict in the task's exit status.
+            if result.returncode != 0:
+                return False, (
+                    f"Run exited {result.returncode}; a valid test with no "
+                    "expected.taskFailure must exit 0.\n"
+                    f"--- Actual output ---\n{output}"
+                )
+        else:
             if result.returncode == 0:
                 return False, (
                     "Expected task failure (non-zero run exit) but the run "


### PR DESCRIPTION
## What changed

187 single-task job fixtures across `base`, `EXPR`, `FEATURE_BUNDLE_1` and
`REDACTED_ENV_VARS` now assert their own output, and `run_openjd_cli_tests.py` now
requires a valid job test to exit `0`.

**1160 passed, 0 failed** on openjd-rs and on openjd-cli 0.7.6. The diff is purely
additive: 187 files, +7856, **−0**.

## Why

`expected.output` is only checkable by a runner that can read the implementation's
stdout. An implementation that can only observe **task status** — a service rather than
a CLI whose pipe the runner holds — gets "a task ran and exited 0", not "it produced the
right answer". `{{Param.Version}}` resolving to `2.0` instead of `1.0` exits 0 and
passes.

Each instrumented case's `onRun` takes one leading argument, an
`OpenJDConformanceAssert` embedded file, followed by its original command and args:

```yaml
      actions:
        onRun:
          command: python
          args:
          - '{{Task.File.OpenJDConformanceAssert}}'
          - python
          - -c
          - print(r'OUTPUT:{{Param.Version}}')
```

The wrapper runs `sys.argv[1:]`, echoes the output verbatim, compares it against
literals baked into itself, and exits non-zero on mismatch. `expected.output` /
`expected.forbidden` are untouched, so a log-scanning runner is unaffected — both
mechanisms now check the same thing by different means.

In-idiom rather than new: `expected.taskFailure` already lets exit status carry a
verdict.

**928 of 1554** declared assertion lines are now checked inside the task:

| bundle | cases | instrumented | lines checked | declared |
|---|---|---|---|---|
| `base` | 167 | 61 | 114 | 453 |
| `EXPR` | 142 | 119 | 802 | 903 |
| `FEATURE_BUNDLE_1` | 13 | 6 | 10 | 16 |
| `REDACTED_ENV_VARS` | 8 | 1 | 2 | 23 |
| `WRAP_ACTIONS` | 65 | 0 | 0 | 139 |
| `TASK_CHUNKING` | 7 | 0 | 0 | 20 |

## Why the argv is passed through rather than embedded

Embedding the original argv in the wrapper's source works for `base` and would have
quietly gutted several EXPR cases. `expr1.3.2--list-flattens-in-args` asserts
`ARG0:--width` … `COUNT:10`; its subject is how the *implementation* expands an args
list, flattening a list value into separate arguments and skipping a null one. Freezing
argv into the wrapper moves that expansion from the implementation into the fixture, so
the case keeps passing while testing nothing.

Passing argv through leaves the expansion where it belongs, and removes every escaping
hazard embedding had.

## Two false passes found on the way

**The runner never checked exit status for a valid case.** A mutation probe — corrupt
what the job prints, leave the expected literal alone — passed:

```
EXPECTED = ["OUTPUT:hello"]   job prints OUTPUT:WRONG
-> OPENJD_CONFORMANCE_ASSERT_FAILED: missing expected output: OUTPUT:hello
-> Process exited with code: 1
-> ✓
```

Two independent causes, both fixed. The runner ignored `returncode` when no
`expected.taskFailure` was declared, so the verdict rested entirely on substring
matching; and the wrapper's diagnostic echoed the expected literal, so the log scan
matched the **error message**. Diagnostics now report `expected output line 1 of 2 not
found` and never the text. The probe reports `✗` on both CLIs now.

The exit-status requirement is a hole in the shared runner independent of the fixtures,
so it is a separate commit.

**46 wrappers that never ran.** All 47 instrumentable `WRAP_ACTIONS` cases passed after
instrumentation, then the success marker showed 46 of them had not executed the wrapper
at all: `onWrapTaskRun` *replaces* the task action, so a hook like
`args: ["-c", "print('TIMEOUT={{WrappedAction.Timeout}}')"]` never runs
`WrappedAction.Command`. Shipping those would have added verification that looks present
and cannot fail — the same failure one layer up. `WRAP_ACTIONS` is excluded wholesale.

That is what `OPENJD_CONFORMANCE_ASSERT_OK: <n> expected, <m> forbidden` is for, and why
it is worth keeping.

## Deliberately left status-only

| left out | why |
|---|---|
| Multi-task cases | Each task sees only its own output; a per-task exit code cannot assert that N lines appeared across N tasks. Needs aggregation outside the job. |
| 9 redaction cases | `4--openjd-redacted-env` expects `SECRET_IS:********`, the implementation's *redaction* of what the task printed. The task sees the real value. `unset-takes-precedence` is the one that does self-assert, because there the variable really is unset. |
| 4 env-output cases | `7.3--env-file-reference` asserts a line printed by a job environment's `onEnter`; its task prints something else. |
| All of `WRAP_ACTIONS` | Above. |
| `wrap-no-args` | It asserts `WrappedAction.Args` surfaces as an empty list when the action has no args. Adding an argument changes the subject. Encoded as a rule: an action with no args is never instrumented. |
| `expected.taskFailure` cases | Already carry their verdict in exit status. |

Every one of these except the first was found by instrumenting the case and watching it
fail, or watching it pass without asserting — not by reading the fixture.

## Testing

| | result |
|---|---|
| openjd-rs `2023-09/*` | 1160 passed, 0 failed |
| openjd-cli 0.7.6 `2023-09/*` | 1160 passed, 0 failed |
| Assertion confirmed to have executed | 180 of 187 on both CLIs |
| Mutation probe | `✗` on both; `✓` before the fixes |
| Original argv, command and `expected` preserved | 187 of 187, checked against the parent commit |

The 7 not confirmed are Windows-only and skipped on a POSIX host
(`7.3--path-param-mapping-windows`, `7.3--rawparam-no-mapping-windows`, four
`expr2.3.2--uri-*-windows`, `6.1--end-of-line-auto-windows`). Each has a POSIX sibling
that passes and differs only in which literal list the wrapper selects, so the risk is
low — but they are genuinely unverified until CI runs them on `windows-latest`.
