### PR TITLE
fix: Specify list string escaping and nested repr_pwsh arrays

### DIFF
--- a/conformance-tests/2023-09/EXPR/jobs/2.12--list-path-param-mapping-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.12--list-path-param-mapping-windows.test.yaml
@@ -32,8 +32,8 @@ pathMapping:
     destination_path: "E:\\cache"
 expected:
   output:
-  - "RAW:[\"D:\\shared\\a.exr\", \"D:\\shared\\b.exr\"]"
-  - "MAPPED:[\"E:\\cache\\a.exr\", \"E:\\cache\\b.exr\"]"
+  - "RAW:[\"D:\\\\shared\\\\a.exr\", \"D:\\\\shared\\\\b.exr\"]"
+  - "MAPPED:[\"E:\\\\cache\\\\a.exr\", \"E:\\\\cache\\\\b.exr\"]"
   - "TASK_MAPPED:E:\\cache\\a.exr"
   - "TASK_MAPPED:E:\\cache\\b.exr"
   - "TASK_RAW:D:\\shared\\a.exr"

--- a/conformance-tests/2023-09/EXPR/jobs/2.12--list-path-param-runtime-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/2.12--list-path-param-runtime-windows.test.yaml
@@ -31,8 +31,8 @@ template:
 expected:
   output:
   - LEN:2
-  - "RAW:[\"renders\\a.exr\", \"renders\\b.exr\"]"
-  - "PATHS:[\"renders\\a.exr\", \"renders\\b.exr\"]"
+  - "RAW:[\"renders\\\\a.exr\", \"renders\\\\b.exr\"]"
+  - "PATHS:[\"renders\\\\a.exr\", \"renders\\\\b.exr\"]"
   - "TASK:renders\\a.exr"
   - "TASK:renders\\b.exr"
   - "TASK_RAW:renders\\a.exr"

--- a/conformance-tests/2023-09/EXPR/jobs/expr1.2.6--list-type-inference.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr1.2.6--list-type-inference.test.yaml
@@ -61,5 +61,5 @@ expected:
   - 'HOMO_PATH:["/a", "/b"]'
   - 'NESTED_PATH:[["/a"], ["/b"]]'
   output_windows:
-  - "HOMO_PATH:[\"\\a\", \"\\b\"]"
-  - "NESTED_PATH:[[\"\\a\"], [\"\\b\"]]"
+  - "HOMO_PATH:[\"\\\\a\", \"\\\\b\"]"
+  - "NESTED_PATH:[[\"\\\\a\"], [\"\\\\b\"]]"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--string-conversion-list-escaping.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.1--string-conversion-list-escaping.test.yaml
@@ -1,0 +1,53 @@
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  steps:
+  - name: Step1
+    # The path list is built in step-level let (TEMPLATE scope) so that path()
+    # uses PurePosixPath for cross-platform consistency (Expression Language
+    # §2.3.2), while rendering still uses native separators.
+    let:
+    - 'paths = [path("/out/a.exr"), path("/out/b.exr")]'
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - |
+            import json
+            # Triple-quoted raw strings so the expressions can contain quotes
+            # and backslashes without Python-level escaping.
+            values = [
+                ('QUOTE', r'''{{ string(['a"b']) }}'''),
+                ('BACKSLASH', r'''{{ string(['a\\b']) }}'''),
+                ('NEWLINE', r'''{{ string(['a\nb']) }}'''),
+                ('TAB', r'''{{ string(['a\tb']) }}'''),
+                ('NUL', r'''{{ string(['\x00']) }}'''),
+                ('NESTED', r'''{{ string([['a"b']]) }}'''),
+                ('PATHS', r'''{{ paths }}'''),
+            ]
+            for name, rendered in values:
+                print(name + ':' + rendered)
+                # Every rendering must be parseable JSON.
+                json.loads(rendered)
+            print('ALL_VALID_JSON')
+expected:
+  output:
+  # `"` and `\` are escaped, so the rendering is valid JSON rather than a
+  # string that terminates early.
+  - 'QUOTE:["a\"b"]'
+  - 'BACKSLASH:["a\\b"]'
+  # Control characters use the JSON short escapes, or \uXXXX where none exists.
+  - 'NEWLINE:["a\nb"]'
+  - 'TAB:["a\tb"]'
+  - 'NUL:["\u0000"]'
+  - 'NESTED:[["a\"b"]]'
+  - 'ALL_VALID_JSON'
+  output_posix:
+  - 'PATHS:["/out/a.exr", "/out/b.exr"]'
+  output_windows:
+  # Backslash path separators must be escaped.
+  - "PATHS:[\"\\\\out\\\\a.exr\", \"\\\\out\\\\b.exr\"]"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--flatten.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.3--flatten.test.yaml
@@ -35,4 +35,4 @@ expected:
   output_posix:
   - 'PATH:["/a", "/b", "/c"]'
   output_windows:
-  - "PATH:[\"\\a\", \"\\b\", \"\\c\"]"
+  - "PATH:[\"\\\\a\", \"\\\\b\", \"\\\\c\"]"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-pwsh-nested-roundtrip-windows.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-pwsh-nested-roundtrip-windows.test.yaml
@@ -1,0 +1,43 @@
+runOn: [windows]
+template:
+  specificationVersion: jobtemplate-2023-09
+  extensions:
+  - EXPR
+  name: TestJob
+  steps:
+  - name: Step1
+    # Round-trip check: the literals repr_pwsh produces must be parsed by a
+    # real PowerShell interpreter back into the same structure. Before the
+    # nested-list fix, repr_pwsh([["a", "b"], ["c"]]) rendered the inner lists
+    # in JSON display form (@(["a", "b"], ["c"])), a PowerShell syntax error.
+    let:
+    - 'nested_val = repr_pwsh([["a", "b"], ["c"]])'
+    - 'nested_single = repr_pwsh([[1, 2]])'
+    script:
+      actions:
+        onRun:
+          command: powershell
+          args:
+          - -NoProfile
+          - -Command
+          - |
+            $ErrorActionPreference = 'Stop'
+            $v = {{ nested_val }}
+            Write-Output ("COUNT:" + $v.Count)
+            Write-Output ("FIRST:" + ($v[0] -join '|'))
+            Write-Output ("FIRST_COUNT:" + $v[0].Count)
+            Write-Output ("SECOND:" + ($v[1] -join '|'))
+            $s = {{ nested_single }}
+            Write-Output ("SINGLE_COUNT:" + $s.Count)
+            Write-Output ("SINGLE_INNER:" + ($s[0] -join '|'))
+expected:
+  output:
+  # @(@('a', 'b'), @('c')): two elements, the first itself a two-element array.
+  - "COUNT:2"
+  - "FIRST:a|b"
+  - "FIRST_COUNT:2"
+  - "SECOND:c"
+  # @(,@(1, 2)): the unary comma keeps the outer list at one element instead
+  # of flattening to @(1, 2).
+  - "SINGLE_COUNT:1"
+  - "SINGLE_INNER:1|2"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-pwsh.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.2.6--repr-pwsh.test.yaml
@@ -15,6 +15,9 @@ template:
     - 'path_val = repr_pwsh(path("/tmp/out"))'
     - "range_val = repr_pwsh(range_expr(\"1-10\"))"
     - "list_val = repr_pwsh([\"a\", \"b\"])"
+    - "nested_val = repr_pwsh([[\"a\", \"b\"], [\"c\"]])"
+    - "nested_single = repr_pwsh([[1, 2]])"
+    - "nested_quote = repr_pwsh([[\"it's\"]])"
     script:
       actions:
         onRun:
@@ -31,6 +34,9 @@ template:
             print(r"PATH:{{ path_val }}")
             print(r"RANGE:{{ range_val }}")
             print(r"LIST:{{ list_val }}")
+            print(r"NESTED:{{ nested_val }}")
+            print(r"NESTED_SINGLE:{{ nested_single }}")
+            print(r"NESTED_QUOTE:{{ nested_quote }}")
 expected:
   output:
   - "STR:'hello'"
@@ -42,3 +48,9 @@ expected:
   - "PATH:'/tmp/out'"
   - "RANGE:'1-10'"
   - "LIST:@('a', 'b')"
+  # Nested lists recurse into PowerShell array syntax rather than JSON display
+  # form. A one-element outer list needs the unary comma to defeat PowerShell's
+  # array flattening: @(@(1, 2)) is @(1, 2), but @(,@(1, 2)) preserves nesting.
+  - "NESTED:@(@('a', 'b'), @('c'))"
+  - "NESTED_SINGLE:@(,@(1, 2))"
+  - "NESTED_QUOTE:@(,@('it''s'))"

--- a/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-scheme-detection.test.yaml
+++ b/conformance-tests/2023-09/EXPR/jobs/expr2.3.1--uri-path-scheme-detection.test.yaml
@@ -58,6 +58,6 @@ expected:
   output_windows:
   # Filesystem paths: PureWindowsPath behavior
   - "POSIX_ABS:\\mnt\\data\\file.txt"
-  - "POSIX_ABS_PARTS:[\"\\\", \"mnt\", \"data\", \"file.txt\"]"
+  - "POSIX_ABS_PARTS:[\"\\\\\", \"mnt\", \"data\", \"file.txt\"]"
   - "POSIX_REL:relative\\path"
   - "COLON:\\mnt\\c:\\data"

--- a/wiki/2026-02-Expression-Language.md
+++ b/wiki/2026-02-Expression-Language.md
@@ -1394,6 +1394,23 @@ sequences.
 
 Note: `int(3.75)` is an error. Use `floor`, `ceil`, or `round` for lossy conversions.
 
+Note: `string()` on a list produces a JSON array: elements separated by `, `,
+`bool`/`int`/`float` bare, nested lists recursed, and `string` and `path`
+elements double-quoted with `"`, `\`, and characters below `U+0020` escaped.
+The result must parse as JSON. For example:
+
+```python
+string(['a"b'])                  # ["a\"b"]
+string([path('C:\out\a.exr')])   # ["C:\\out\\a.exr"]
+```
+
+Escaping non-ASCII is optional, since JSON accepts those characters directly:
+`["café"]` and `["caf\u00e9"]` are both valid. Use `repr_json` (section 2.2.6)
+where the `\uXXXX` form is required.
+
+Format string interpolation with surrounding text (section 1.3.2) uses this same
+conversion, so `"items: {{ MyList }}"` and `"items: " + string(MyList)` agree.
+
 Note: `bool()` string conversion accepts the following case-insensitive values:
 `"1"`, `"true"`, `"on"`, `"yes"` become `true`; `"0"`, `"false"`, `"off"`, `"no"` become `false`.
 All other string values are rejected with an error.
@@ -1682,7 +1699,10 @@ have well-defined string escaping.
 
 `repr_pwsh` produces PowerShell literals with proper escaping. Strings and paths are wrapped in
 single quotes with embedded single quotes doubled. Booleans become `$true`/`$false`. Lists become
-PowerShell array syntax `@(...)`.
+PowerShell array syntax `@(...)`, with nested lists rendered recursively in the same form. A
+one-element list whose element is itself a list uses the unary comma form `@(,...)`, because
+`@(@(1, 2))` flattens to `@(1, 2)` under PowerShell's array-flattening rules while `@(,@(1, 2))`
+preserves the nesting.
 
 `repr_py` follows the behavior of Python's
 [repr](https://docs.python.org/3/library/functions.html#repr).
@@ -1694,6 +1714,8 @@ Examples:
 - `repr_cmd("hello!")` returns `"\"hello^^!\""` (`!` escaped as `^^!` for the delayed expansion context)
 - `repr_cmd("a\nb")` returns `"\"ab\""` (newlines stripped)
 - `repr_pwsh(["a", "b"])` returns `@('a', 'b')`
+- `repr_pwsh([["a", "b"], ["c"]])` returns `@(@('a', 'b'), @('c'))`
+- `repr_pwsh([[1, 2]])` returns `@(,@(1, 2))` (unary comma preserves the single-element nesting)
 - `repr_py("hello\nworld")` returns `"'hello\\nworld'"`
 - `repr_json([1, 2, 3])` returns `"[1, 2, 3]"`
 


### PR DESCRIPTION
*Description of the change. What is being added or fixed?*

This change was prompted by a bug report against the Rust implementation
([openjd-rs#312](https://github.com/OpenJobDescription/openjd-rs/issues/312)).
Chasing it down showed that the specification is clear about what should
happen, but the conformance test suite had accidentally frozen the buggy
behaviour, so implementations were being tested against the wrong answer.
This PR fixes the tests and spells out the rule the spec was relying on
implicitly. Auditing the fix also turned up a second, related gap — how
`repr_pwsh` renders nested lists — which is specified and tested here too.

**The background.** Job templates can contain expressions, and the `string()`
function turns an expression's value into text. For most values that is
obvious — the number `42` becomes `42`. For a list, the spec says the result
is "the JSON string representation", so the list of two file names becomes
`["a.exr", "b.exr"]`.

**The problem.** JSON marks the start and end of a piece of text with double
quotes. So if a piece of text *contains* a double quote, that quote has to be
written as `\"` — otherwise a reader sees it as the closing quote and the
value ends in the wrong place. The same is true for a backslash, which has to
be written as `\\`, and for characters like tab and newline. This is called
escaping, and it is not optional: JSON without it is not JSON.

Implementations were putting quotes around each element but not escaping
what was inside them. A list holding the single item `a"b` came out as
`["a"b"]`, which no JSON reader will accept. The most common way to hit this
is not an unusual file name, though — it is Windows, where every path
separator is a backslash. A list of two Windows paths came out as:

```
["C:\out\a.exr", "C:\out\b.exr"]
```

That is not valid JSON, and worse, it is quietly misleading: in most
languages `\a` and `\b` mean "bell" and "backspace", so anything that reads
this string can silently end up with different characters than the file names
it was given. The correct rendering doubles each backslash:

```
["C:\\out\\a.exr", "C:\\out\\b.exr"]
```

**Why the tests didn't catch it.** The only existing conformance case that
calls `string()` on a list uses `[1, 2, 3]`, which has no characters that need
escaping. Meanwhile five *other* tests do render lists of paths — through
format string interpolation, which the spec says converts values the same way
`string()` does — and their `output_windows` expectations were written by
recording what implementations actually produced. So they had the unescaped
output baked in as the expected result.

**What this PR changes.**

1. The five `output_windows` expectations are corrected to the escaped form.
   The affected tests are `expr2.2.3--flatten`,
   `expr1.2.6--list-type-inference`, `expr2.3.1--uri-path-scheme-detection`,
   and both `2.12--list-path-param-*-windows`. Their POSIX expectations are
   unchanged, because forward slashes need no escaping — which is exactly why
   this went unnoticed for so long.

2. A new test, `expr2.2.1--string-conversion-list-escaping`, covers a double
   quote, a backslash, a newline, a tab, a null character, a nested list, and
   a list of paths. As well as checking the exact text, it hands each result
   to a JSON parser, so the test pins the property that actually matters
   rather than just one spelling of it.

3. The Expression Language page (section 2.2.1) gains a note stating the rule
   directly: elements are separated by `, `; numbers and booleans render bare;
   nested lists recurse; strings and paths are double-quoted with `"`, `\`,
   and every character below `U+0020` escaped. It also states that this same
   conversion is what format string interpolation uses, so
   `"items: {{ MyList }}"` and `"items: " + string(MyList)` are guaranteed to
   agree.

4. The `repr_pwsh` section (2.2.6) now says what a nested list produces.
   The spec only said lists become PowerShell array syntax `@(...)`, and the
   Rust implementation was rendering the *inner* lists in JSON form —
   `repr_pwsh([["a", "b"], ["c"]])` gave `@(["a", "b"], ["c"])`, which
   PowerShell rejects as a syntax error. The spec now states that nested
   lists render recursively as `@(...)`, and that a one-element outer list
   uses the unary comma form `@(,@(1, 2))` — necessary because PowerShell
   flattens `@(@(1, 2))` down to `@(1, 2)`.

5. Tests for the `repr_pwsh` rule: the existing `expr2.2.6--repr-pwsh` test
   gains assertions for the nested forms, and a new Windows-only test,
   `expr2.2.6--repr-pwsh-nested-roundtrip-windows`, feeds the rendered
   literals to a real PowerShell interpreter and checks that it reads back
   the same structure — element counts and values, with no flattening.

**One case left open on purpose.** Accented letters, emoji, and other
non-ASCII characters do *not* have to be escaped — JSON accepts them as they
are. So an implementation can write `["café"]` or `["caf\u00e9"]`, and both
are correct. The note says this is up to the implementation and holds them to
the one thing that matters: the result has to parse as JSON. Templates that
need a specific form should use `repr_json` (section 2.2.6), which *is*
specified to escape non-ASCII.

For the same reason, non-ASCII is not part of the new conformance test — the
suite should only assert what the spec requires. (There is a practical reason
too: the test runs a Python script and compares its printed output, and
whether non-ASCII survives that round trip depends on the encoding the task's
Python uses for its output stream, which varies by platform and version. Those
failures would say nothing about the implementation under test.)

Nothing here changes what the spec asks for. RFC 0006 already defined the
list-to-string conversion as a JSON representation; these edits make the
escaping requirement explicit and stop the test suite from asserting the
opposite.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
