### PR TITLE
fix: Specify how a numeric string's leading and trailing zeros render

### DIFF
--- a/conformance-tests/2023-09/base/jobs/7.5--numeric-string-zeros-in-range-elements.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.5--numeric-string-zeros-in-range-elements.test.yaml
@@ -1,0 +1,86 @@
+# The two kinds of zero in an <intstring>/<floatstring> range element are not the same thing, and
+# this pins both directions at once (Template Schemas §7.5, added alongside this fixture).
+#
+#   Leading zeros are not part of the value and are removed. '02' on an INT range is the task
+#   value 2; forwarding the text invokes a renderer with `--frame 02`. Already pinned for a
+#   parameter default by base/jobs/2.3--int-param-intstring-default-resolves.test.yaml, which
+#   asserts COUNT:7 from default '007'.
+#
+#   The decimal places a <floatstring> is written with are preserved. '2.50' renders 2.50, not
+#   2.5. This is the reason the string form exists — a <float> literal cannot ask for a fixed
+#   number of decimal places, because 2.50 and 2.5 are the same literal after parsing, and
+#   renderers commonly require a fixed number. Already pinned for a parameter default by
+#   EXPR/jobs/expr1.3.4--float-passthrough.test.yaml, which asserts PARAM:3.500 from default
+#   "3.500". This fixture extends the same rule to a range element.
+#
+# '0.50' is included because its leading zero is NOT redundant — it is the whole integer part —
+# so an implementation that strips leading zeros by text must still leave one digit behind.
+#
+# Note for reviewers: the assertions bracket the value (`W[2.50]`) rather than delimiting it with
+# a colon. The test runner matches expected output as a substring, so a bare `W:2.5` matches a
+# line reading `W:2.50` and the fixture would pass against either behaviour. The closing bracket
+# is what makes the `forbidden` entries below actually forbid anything.
+#
+# Deliberately not covered, because §7.5 leaves them unspecified and implementations differ:
+# exponent notation ('1E+2'), an explicit leading '+' ('+2.50'), and zero-valued <floatstring>s
+# ('0.00'), where one implementation collapses the value to 0.0 and loses the written scale.
+#
+# Spec references, Template Schemas 2023-09:
+#   §7.5  Numeric strings — how a numeric string's value is rendered, and the two zero rules
+#     https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md?plain=1#L2034
+#   §3.4.1.1 L1112  `<IntRangeList>` elements are `<integer> | <intstring>`
+#     https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md?plain=1#L1112
+#   §3.4.1.2 L1187  `<FloatRangeList>` elements are `<float> | <floatstring>`
+#     https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md?plain=1#L1187
+template:
+  specificationVersion: jobtemplate-2023-09
+  name: TestJob
+  steps:
+  - name: FloatRange
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: Weight
+        type: FLOAT
+        range: ['2.50', '03.500', '0.50', '1.5']
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print(r'W[{{Task.Param.Weight}}]')
+  - name: IntRange
+    parameterSpace:
+      taskParameterDefinitions:
+      - name: Frame
+        type: INT
+        range: ['1', '02', '003']
+    script:
+      actions:
+        onRun:
+          command: python
+          args:
+          - -c
+          - print(r'F[{{Task.Param.Frame}}]')
+expected:
+  output:
+  # A <floatstring> keeps the decimal places it was written with, and loses only
+  # the leading zero of '03.500'.
+  - 'W[2.50]'
+  - 'W[3.500]'
+  - 'W[0.50]'
+  - 'W[1.5]'
+  # An <intstring> renders as the integer it denotes.
+  - 'F[1]'
+  - 'F[2]'
+  - 'F[3]'
+  forbidden:
+  # Normalizing a <floatstring> to the number it denotes: the decimal places are
+  # part of what the element asked for.
+  - 'W[2.5]'
+  - 'W[3.5]'
+  - 'W[0.5]'
+  # Forwarding the source text unchanged: the leading zeros are not.
+  - 'W[03.500]'
+  - 'F[02]'
+  - 'F[003]'

--- a/conformance-tests/2023-09/base/jobs/7.5--numeric-string-zeros-in-range-elements.test.yaml
+++ b/conformance-tests/2023-09/base/jobs/7.5--numeric-string-zeros-in-range-elements.test.yaml
@@ -1,37 +1,13 @@
-# The two kinds of zero in an <intstring>/<floatstring> range element are not the same thing, and
-# this pins both directions at once (Template Schemas §7.5, added alongside this fixture).
+# Template Schemas §7.5: a numeric string loses notation redundant to its value (leading zeros, a
+# leading '+') and keeps notation it was written in (decimal places, an exponent).
 #
-#   Leading zeros are not part of the value and are removed. '02' on an INT range is the task
-#   value 2; forwarding the text invokes a renderer with `--frame 02`. Already pinned for a
-#   parameter default by base/jobs/2.3--int-param-intstring-default-resolves.test.yaml, which
-#   asserts COUNT:7 from default '007'.
+# Both halves over FLOAT and INT range elements. '0.50' is here because its leading zero is the
+# whole integer part. The exponent elements carry a dot ('2.50E+2', not '1E+2') because the runner
+# re-dumps the template through PyYAML, which leaves a dotless exponent unquoted, and a YAML 1.2
+# parser then reads it as a <float> literal that makes no request at all. Assertions bracket the
+# value because the runner substring-matches, so a bare 'W:2.5' is satisfied by 'W:2.50'.
 #
-#   The decimal places a <floatstring> is written with are preserved. '2.50' renders 2.50, not
-#   2.5. This is the reason the string form exists — a <float> literal cannot ask for a fixed
-#   number of decimal places, because 2.50 and 2.5 are the same literal after parsing, and
-#   renderers commonly require a fixed number. Already pinned for a parameter default by
-#   EXPR/jobs/expr1.3.4--float-passthrough.test.yaml, which asserts PARAM:3.500 from default
-#   "3.500". This fixture extends the same rule to a range element.
-#
-# '0.50' is included because its leading zero is NOT redundant — it is the whole integer part —
-# so an implementation that strips leading zeros by text must still leave one digit behind.
-#
-# Note for reviewers: the assertions bracket the value (`W[2.50]`) rather than delimiting it with
-# a colon. The test runner matches expected output as a substring, so a bare `W:2.5` matches a
-# line reading `W:2.50` and the fixture would pass against either behaviour. The closing bracket
-# is what makes the `forbidden` entries below actually forbid anything.
-#
-# Deliberately not covered, because §7.5 leaves them unspecified and implementations differ:
-# exponent notation ('1E+2'), an explicit leading '+' ('+2.50'), and zero-valued <floatstring>s
-# ('0.00'), where one implementation collapses the value to 0.0 and loses the written scale.
-#
-# Spec references, Template Schemas 2023-09:
-#   §7.5  Numeric strings — how a numeric string's value is rendered, and the two zero rules
-#     https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md?plain=1#L2034
-#   §3.4.1.1 L1112  `<IntRangeList>` elements are `<integer> | <intstring>`
-#     https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md?plain=1#L1112
-#   §3.4.1.2 L1187  `<FloatRangeList>` elements are `<float> | <floatstring>`
-#     https://github.com/OpenJobDescription/openjd-specifications/blob/mainline/wiki/2023-09-Template-Schemas.md?plain=1#L1187
+# A normalizing implementation misses W[2.50] and W[2.50E+2]; one forwarding text misses F[2].
 template:
   specificationVersion: jobtemplate-2023-09
   name: TestJob
@@ -41,7 +17,7 @@ template:
       taskParameterDefinitions:
       - name: Weight
         type: FLOAT
-        range: ['2.50', '03.500', '0.50', '1.5']
+        range: ['2.50', '03.500', '0.50', '1.5', '2.50E+2', '1.0e-3', '+4.25']
     script:
       actions:
         onRun:
@@ -54,7 +30,7 @@ template:
       taskParameterDefinitions:
       - name: Frame
         type: INT
-        range: ['1', '02', '003']
+        range: ['1', '02', '003', '+7']
     script:
       actions:
         onRun:
@@ -64,23 +40,28 @@ template:
           - print(r'F[{{Task.Param.Frame}}]')
 expected:
   output:
-  # A <floatstring> keeps the decimal places it was written with, and loses only
-  # the leading zero of '03.500'.
   - 'W[2.50]'
   - 'W[3.500]'
   - 'W[0.50]'
   - 'W[1.5]'
-  # An <intstring> renders as the integer it denotes.
+  - 'W[2.50E+2]'
+  - 'W[1.0e-3]'
+  - 'W[4.25]'
   - 'F[1]'
   - 'F[2]'
   - 'F[3]'
+  - 'F[7]'
   forbidden:
-  # Normalizing a <floatstring> to the number it denotes: the decimal places are
-  # part of what the element asked for.
+  # Normalizing to the number the element denotes.
   - 'W[2.5]'
   - 'W[3.5]'
   - 'W[0.5]'
-  # Forwarding the source text unchanged: the leading zeros are not.
+  - 'W[250]'
+  - 'W[250.0]'
+  - 'W[0.001]'
+  # Forwarding the source text unchanged.
   - 'W[03.500]'
+  - 'W[+4.25]'
   - 'F[02]'
   - 'F[003]'
+  - 'F[+7]'

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -315,7 +315,8 @@ userInterface:  # @optional
 
 ```
 
-Where `<intstring>` is a string whose value is the string representation of an integer value in base-10, and:
+Where `<intstring>` is a string whose value is the string representation of an integer value in base-10
+(see [Numeric strings](#75-numeric-strings) for how such a value is rendered), and:
 
 1. *name* — The name by which the parameter is referenced. See: [&lt;Identifier&gt;](#71-identifier).
 2. *description* — A description to apply to the parameter. It has no functional purpose, but may appear in UI elements.
@@ -373,7 +374,8 @@ userInterface: # @optional
 ```
 
 Where `<floatstring>` is a string whose value is the string representation of a floating point or integer value in
-base-10, and:
+base-10 (see [Numeric strings](#75-numeric-strings) for how such a value is rendered, including the decimal places it
+was written with), and:
 
 1. *name* — The name by which the parameter is referenced. See: [&lt;Identifier&gt;](#71-identifier).
 2. *description* — A description to apply to the parameter. It has no functional purpose, but may appear in UI elements.
@@ -1112,7 +1114,8 @@ With:
 
 Where `<intstring>` is a string whose value is the string representation of an integer value in base-10,
 `<TaskParameterStringValue>` (See [&lt;TaskParameterStringValue&gt;](#342-taskparameterstringvalue)) must resolve to the
-string representation of an integer value in base-10, and:
+string representation of an integer value in base-10, both are rendered as described in
+[Numeric strings](#75-numeric-strings), and:
 
 1. *name* — The name of the parameter.
 2. *type* — The literal "INT", defining this parameter as integer valued.
@@ -1186,7 +1189,9 @@ With:
 
 Where `<floatstring>` is a string whose value is the string representation of a floating point value in base-10,
 `<TaskParameterStringValue>` (See [&lt;TaskParameterStringValue&gt;](#342-taskparameterstringvalue)) must resolve to the
-string representation of a floating point value in base-10, and:
+string representation of a floating point value in base-10, both are rendered as described in
+[Numeric strings](#75-numeric-strings) — which preserves the decimal places the element was written with, so a range
+element of `'2.50'` gives a Task the value `2.50` — and:
 
 1. *name* — The name of the parameter.
 2. *type* — The literal "FLOAT", defining this parameter as floating point valued.
@@ -2025,6 +2030,45 @@ execution time on the worker host.
 With the `EXPR` extension enabled, expressions that reference values not yet known at a given
 stage are type-checked using the declared types of those values, catching type errors as early
 as possible. See the [Expression Language](2026-02-Expression-Language) specification for details.
+
+### 7.5. Numeric strings
+
+`<intstring>`, `<floatstring>`, and `<posintstring>` are the string forms of a number. A field
+that accepts one of them accepts the number written as text wherever it would otherwise accept an
+`<integer>`, `<float>`, or `<positiveint>` literal.
+
+Such a value is eventually rendered back into text — into a format string result, and from there
+onto a Task's command line — so what it renders as is part of what the Template asked for. Two
+rules govern the zeros in it, and they differ:
+
+1. **Redundant leading zeros are not part of the value, and are removed.** An `<intstring>` of
+   `'007'` is the value 7, and renders `7`. A leading zero that is not redundant is kept: the `0`
+   in a `<floatstring>` of `'0.50'` is the whole of its integer part, and `'000'` denotes 0. So a
+   `<floatstring>` of `'02.50'` renders `2.50`.
+
+2. **The decimal places a `<floatstring>` is written with are part of what it asks for, and are
+   preserved.** A `<floatstring>` of `'2.50'` renders `2.50`, not `2.5`, and one of `'3.500'`
+   renders `3.500`. Renderers and other Task commands commonly require a fixed number of decimal
+   places, and writing the value as a string is how a Template asks for one. A `<float>` literal
+   cannot do this, because the number of decimal places a literal was written with is not
+   preserved through parsing — a `<float>` of `2.50` is the same value as `2.5`.
+
+An `<intstring>` and a `<posintstring>` have no decimal places, so rule 1 is the whole of their
+behaviour: each renders as the integer it denotes.
+
+Rule 2 is the reason the two rules are not one rule. Both kinds of zero are redundant to the
+*value*, but only the leading ones are redundant to the *request*: `'02'` and `'2'` ask for the
+same thing, while `'2.50'` and `'2.5'` do not.
+
+Two things are deliberately left unspecified in this revision, because no conformance fixture
+pins them and implementations differ:
+
+* Whether a numeric string written in exponent notation renders in exponent notation. A
+  `<floatstring>` of `'1E+2'` may render `1E+2` or `100`.
+* Whether an explicit leading `+` is preserved. A `<floatstring>` of `'+2.50'` may render
+  `+2.50` or `2.50`.
+
+A Template that needs a specific answer to either should write the value it wants.
 
 ## 8. `<SimpleAction>`
 

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -2037,38 +2037,25 @@ as possible. See the [Expression Language](2026-02-Expression-Language) specific
 that accepts one of them accepts the number written as text wherever it would otherwise accept an
 `<integer>`, `<float>`, or `<positiveint>` literal.
 
-Such a value is eventually rendered back into text — into a format string result, and from there
-onto a Task's command line — so what it renders as is part of what the Template asked for. Two
-rules govern the zeros in it, and they differ:
+Such a value is rendered back into text — into a format string result, and from there onto a Task's
+command line — so how it was written is part of what the Template asked for. Two rules govern that:
 
-1. **Redundant leading zeros are not part of the value, and are removed.** An `<intstring>` of
-   `'007'` is the value 7, and renders `7`. A leading zero that is not redundant is kept: the `0`
-   in a `<floatstring>` of `'0.50'` is the whole of its integer part, and `'000'` denotes 0. So a
-   `<floatstring>` of `'02.50'` renders `2.50`.
+1. **Notation redundant to the value is removed.** Redundant leading zeros and a leading `+` both
+   are: an `<intstring>` of `'007'` renders `7`, and a `<floatstring>` of `'+2.50'` renders `2.50`.
+   A leading zero that is not redundant is kept, so `'0.50'` renders `0.50` and `'02.50'` renders
+   `2.50`.
 
-2. **The decimal places a `<floatstring>` is written with are part of what it asks for, and are
-   preserved.** A `<floatstring>` of `'2.50'` renders `2.50`, not `2.5`, and one of `'3.500'`
-   renders `3.500`. Renderers and other Task commands commonly require a fixed number of decimal
-   places, and writing the value as a string is how a Template asks for one. A `<float>` literal
-   cannot do this, because the number of decimal places a literal was written with is not
-   preserved through parsing — a `<float>` of `2.50` is the same value as `2.5`.
+2. **Notation the value was written in is preserved.** Decimal places and an exponent both are:
+   `'2.50'` renders `2.50` and not `2.5`, and `'1E+2'` renders `1E+2` and not `100`. An exponent
+   keeps the case of its marker and the sign inside it. Writing the value as a string is the only
+   way a Template can ask for a fixed number of decimal places, which renderers commonly require;
+   a `<float>` literal cannot, because `2.50` and `2.5` are the same literal after parsing.
 
-An `<intstring>` and a `<posintstring>` have no decimal places, so rule 1 is the whole of their
-behaviour: each renders as the integer it denotes.
+An `<intstring>` and a `<posintstring>` have no decimal places and no exponent, so rule 1 is the
+whole of their behaviour: each renders as the integer it denotes.
 
-Rule 2 is the reason the two rules are not one rule. Both kinds of zero are redundant to the
-*value*, but only the leading ones are redundant to the *request*: `'02'` and `'2'` ask for the
-same thing, while `'2.50'` and `'2.5'` do not.
-
-Two things are deliberately left unspecified in this revision, because no conformance fixture
-pins them and implementations differ:
-
-* Whether a numeric string written in exponent notation renders in exponent notation. A
-  `<floatstring>` of `'1E+2'` may render `1E+2` or `100`.
-* Whether an explicit leading `+` is preserved. A `<floatstring>` of `'+2.50'` may render
-  `+2.50` or `2.50`.
-
-A Template that needs a specific answer to either should write the value it wants.
+The sign of a zero is left unspecified in this revision: a `<floatstring>` of `'-0.00'` may render
+`-0.00` or `0.00`.
 
 ## 8. `<SimpleAction>`
 


### PR DESCRIPTION
## What

Adds **§7.5 Numeric strings**, which says what an `<intstring>`/`<floatstring>` renders as, and one conformance fixture that pins it for range elements.

The rule, in one line: **leading zeros go, trailing zeros stay.**

```yaml
- name: Weight
  type: FLOAT
  range: ['2.50', '03.500', '0.50']   # -> 2.50   3.500   0.50

- name: Frame
  type: INT
  range: ['02', '003']                # -> 2      3
```

## Why the spec needs to say this

`<intstring>` and `<floatstring>` are defined only as "a string whose value is the string representation of" a number. That says what the element *denotes*; it does not say what it *renders as*. Implementations read it both ways, and two already-landed fixtures pull in opposite directions:

| Fixture | Asserts | Reading |
|---|---|---|
| `base/jobs/2.3--int-param-intstring-default-resolves` | `COUNT:7` from INT `default: '007'` | text is **not** preserved |
| `EXPR/jobs/expr1.3.4--float-passthrough` | `PARAM:3.500` from FLOAT `default: "3.500"` | text **is** preserved |

Both are right, and the reason is that the two kinds of zero are not the same thing:

- Leading zeros are redundant to the **value**. `'02'` and `'2'` ask for the same thing, and forwarding the text invokes a renderer with `--frame 02`.
- Trailing zeros are not redundant to the **request**. A fixed number of decimal places is something renderers commonly require, and the string form is the only way a Template can ask for one — a `<float>` literal cannot, because `2.50` and `2.5` are the same literal after parsing.

This came out of review on openjd-model-for-python#342, which normalized range elements to the number they denote and so dropped the trailing zeros. openjd-model-for-python#345 reverts that half; this PR is the spec statement behind it.

`base/jobs/3.4.1.2--float-range-floatstring-elements-normalized` in #179 states the fully-normalizing reading for a FLOAT range element. Its own comment flagged that it and `expr1.3.4--float-passthrough` could not both be right and that a ruling was needed. This is the ruling, and 3.4.1.2 is the one that moves — see the note on #179 below.

## Rulings added in review

Review asked for a specific choice on the two cases §7.5 first left unspecified, rather than leaving a reader to infer one. Both follow the split the section already makes, so they landed inside the existing two rules rather than as exceptions:

| Case | Ruling | Rule it joins |
|---|---|---|
| Exponent notation | `'1E+2'` renders `1E+2`, keeping the case of its marker and the sign inside it | 2, with decimal places |
| Leading `+` | `'+2.50'` renders `2.50` | 1, with redundant leading zeros |

§7.5 went from 36 lines to 24 in the process. Only the sign of a zero is still open, and that is now one sentence rather than a bulleted list.

## The fixture

`base/jobs/7.5--numeric-string-zeros-in-range-elements.test.yaml`, covering INT and FLOAT range elements in one template. `'0.50'` is in there because its leading zero is **not** redundant, it is the whole integer part, so an implementation that strips leading zeros by text has to leave one digit behind. Header trimmed from 34 comment lines to 10; every other fixture in that directory has at most 4.

Two details worth flagging for reviewers.

The assertions bracket each value (`W[2.50]`) rather than delimiting with a colon. **The runner matches expected output as a substring**, so an assertion of `W:2.5` is satisfied by a line reading `W:2.50`. The closing bracket is what makes the `forbidden` entries forbid anything. `base/jobs/3.4.1.2` in #179 has exactly that defect and reports a pass against either behaviour.

The exponent elements are spelled with a dot (`'2.50E+2'`, not `'1E+2'`) because **the runner re-dumps the template through PyYAML**, whose YAML 1.1 resolver needs a dot before an exponent and so leaves `1E+2` unquoted. A YAML 1.2 parser then reads that plain scalar as a number, i.e. a `<float>` literal, which makes no request about rendering at all. Measured: openjd-rs renders `100.0` for an unquoted `1E+2` and `2.50E+2` for the quoted form. Asserting on `'1E+2'` here would have tested scalar resolution rather than §7.5.

## Verification

Measured against both implementations at their current mainline, after the rulings above:

| Implementation | Scope | Result |
|---|---|---|
| openjd-rs `d67bfb8` | full `2023-09/*` | **1178 passed, 1 failed** |
| openjd-model 0.11.9 + openjd-cli 0.7.7 | `2023-09/base/*` | **656 passed, 1 failed** |

In both, the single failure is this fixture and nothing else, and in both it fails on the leading `+` alone: they render `W[+4.25]` where §7.5 now requires `W[4.25]`. Every other element passes, including both exponent elements, so **the exponent ruling ratifies what both already ship on this surface and only the `+` ruling needs code**.

The Python full suite was not run to completion: it wedges on an unrelated EXPR range-cap fixture (a `LIST[INT]` range supplied beyond the list cap) that ran for minutes without finishing. Nothing to do with this change, but it is why the Python row is scoped to `base`.

Per-element, both surfaces:

| Source | Surface | openjd-rs | Python | §7.5 |
|---|---|---|---|---|
| `'2.50'` | FLOAT range | `2.50` | `2.50` | `2.50` |
| `'03.500'` | FLOAT range | `3.500` | `3.500` | `3.500` |
| `'0.50'` | FLOAT range | `0.50` | `0.50` | `0.50` |
| `'2.50E+2'` | FLOAT range | `2.50E+2` | `2.50E+2` | `2.50E+2` |
| `'1.0e-3'` | FLOAT range | `1.0e-3` | `1.0e-3` | `1.0e-3` |
| `'+4.25'` | FLOAT range | **`+4.25`** | **`+4.25`** | `4.25` |
| `'02'`, `'003'`, `'+7'` | INT range | `2`, `3`, `7` | `2`, `3`, `7` | same |
| `'+2.50'` | FLOAT default | **`+2.50`** | `2.50` | `2.50` |
| `'03.500'` | FLOAT default | **`03.500`** | `3.500` | `3.500` |
| `'2.50E+2'` | FLOAT default | `2.50E+2` | **`250`** | `2.50E+2` |
| `'1.0e-3'` | FLOAT default | `1.0e-3` | **`0.0010`** | `1.0e-3` |
| `'+7'` | INT default | `7` | `7` | `7` |

The fixture pins the range rows only. The default rows are unpinned by any fixture and are filed against the implementations rather than widened into this PR: openjd-rs applies no §7.5 rule 1 at all on that surface (`coerce_from_str`, `create_job/parameters.rs`), and Python renders it with `str(Decimal(...))` semantics, which keep significant digits but not the written notation.

## CI will fail until both implementations release

Both conformance workflows install released versions (`pip install openjd-cli`, `cargo install openjd-cli`), so this fixture fails there until the `+` fix ships in each. Released Python 0.11.6 additionally predates openjd-model-for-python#345 and fails on the leading-zero side too.

One unrelated failure appears in the Python job on Windows, `3.4--path-parameter`. It fails on `mainline` too, so it is a pre-existing baseline failure and not a regression from this PR.

## Also left out

The sign of a zero. Both implementations render zero's sign away but differ on whether the decimal places survive it, so §7.5 says the case is unspecified rather than guessing.

## Related

- openjd-model-for-python#345 — the implementation of this rule, and the revert of the trailing-zero normalization.
- openjd-model-for-python#342 — where the normalization came from, and the review comment that prompted the ruling.
- OpenJobDescription/openjd-rs#354 — the same rule in openjd-rs, including the `Float64::with_str` guard that was dropping the decimal places of any zero.
- #179 — carries `3.4.1.1` and `3.4.1.2`. `3.4.1.1` (INT) agrees with §7.5 as written. `3.4.1.2` asserts `W:2.5` from `'02.50'` and needs to become `W:2.50`, with a terminator so substring matching cannot hide it. Flagging rather than editing that branch from here.

