### PR TITLE
docs: clarify stepEnvironment name scope; add cross-step same-name fixture

### DIFF
--- a/conformance-tests/2023-09/base/job_templates/4--same-step-env-name-across-steps.yaml
+++ b/conformance-tests/2023-09/base/job_templates/4--same-step-env-name-across-steps.yaml
@@ -1,0 +1,31 @@
+specificationVersion: jobtemplate-2023-09
+name: TestJob
+jobEnvironments:
+- name: JobEnv
+  variables:
+    JOB_VAR: value
+steps:
+- name: Step1
+  stepEnvironments:
+  - name: StepEnv
+    variables:
+      VAR1: value1
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"
+- name: Step2
+  stepEnvironments:
+  - name: StepEnv
+    variables:
+      VAR1: value2
+  script:
+    actions:
+      onRun:
+        command: python
+        args:
+        - "-c"
+        - "print()"

--- a/wiki/2023-09-Template-Schemas.md
+++ b/wiki/2023-09-Template-Schemas.md
@@ -872,6 +872,9 @@ Where:
         1. No two Environments in this list may have the same value for the `name` property.
         2. The Environments defined in this list must not have the same `name` as a Job Environment defined in the same
            Job Template.
+    * Note: The scope of a Step Environment's `name` is the Step that defines it. Different Steps may each define a
+      Step Environment with the same `name`; a Session only ever contains the Step Environments of a single Step, so
+      these names never collide.
 6. *hostRequirements* — Describes the requirements on Worker host's capabilities that must be satisfied for the Task(s) of
    the Step to be scheduled to the host. See: [&lt;HostRequirements&gt;](#33-hostrequirements).
 7. *parameterSpace* — Defines the parameterization of the Step's action; the available parameters, the values that they
@@ -1494,7 +1497,8 @@ variables: <EnvironmentVariables> # @optional
 
 Where:
 
-1. *name* — An identifier given to the environment that is unique within the Environment's defined scope.
+1. *name* — An identifier given to the environment that is unique within the Environment's defined scope: the Job
+   Template for a Job Environment, and the Step Template for a Step Environment.
 2. *description* — A description to apply to the environment. It has no functional purpose, but may appear in UI elements.
    See: [&lt;Description&gt;](#72-description).
 3. *script* — The action that is taken by this Environment when it is run on a Worker host.


### PR DESCRIPTION
*Description of the change. What is being added or fixed?*

**Wiki (2023-09-Template-Schemas.md), clarification only, no rule change.**

Section 3 (`StepTemplate.stepEnvironments`) lists what a Step Environment `name` must not collide with: other entries in the same list, and any Job Environment. It does not state that different Steps may reuse a name, and one implementation read that omission as a fourth rule and rejected such templates (OpenJobDescription/openjd-rs#380, fixed in OpenJobDescription/openjd-rs#381). This PR:

- adds a Note under the Section 3 constraints: a Step Environment's `name` is scoped to the Step that defines it; different Steps may each define a Step Environment with the same `name`, since a Session only ever contains one Step's environments.
- names the two scopes in Section 4 (`Environment.name`): the Job Template for a Job Environment, the Step Template for a Step Environment.

The set of valid templates is unchanged before and after this wording.

**Conformance fixture** `conformance-tests/2023-09/base/job_templates/4--same-step-env-name-across-steps.yaml` (valid): one `jobEnvironments` entry plus two Steps that each define a Step Environment named `StepEnv`. The existing Section 4 fixtures cover the three prohibitions (`4--duplicate-job-env-names.invalid`, `4--duplicate-step-env-names.invalid`, step-vs-job); none covers the allowed cross-step case, which is why the over-strict check went unnoticed.

Verified with `openjd` CLI built from openjd-rs: rejected at `upstream/main` before the fix (`steps[1] -> stepEnvironments[0]: duplicate environment name: 'StepEnv'`), accepted on the fix branch; all Section 4 fixtures pass there. Python (openjd-model-for-python) accepts the same shape.

Note for consumers pinning this suite: an implementation without the openjd-rs#381 fix will fail this fixture until it picks up the fix.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
